### PR TITLE
fix some cli parsing bugs and add unit test coverage

### DIFF
--- a/pkg/cli/cli_internal_test.go
+++ b/pkg/cli/cli_internal_test.go
@@ -1,0 +1,48 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cli
+
+import (
+	"os"
+	"testing"
+
+	h "github.com/aws/amazon-ec2-instance-selector/pkg/test"
+	"github.com/spf13/pflag"
+)
+
+// Tests
+
+func TestRemoveIntersectingArgs(t *testing.T) {
+	flagSet := pflag.NewFlagSet("test-flag-set", pflag.ContinueOnError)
+	flagSet.Bool("test-bool", false, "test usage")
+	os.Args = []string{"ec2-instance-selector", "--test-bool", "--this-should-stay"}
+	newArgs := removeIntersectingArgs(flagSet)
+	h.Assert(t, len(newArgs) == 2, "NewArgs should only include the bin name and one argument after removing intersections")
+}
+
+func TestRemoveIntersectingArgs_NextArg(t *testing.T) {
+	flagSet := pflag.NewFlagSet("test-flag-set", pflag.ContinueOnError)
+	flagSet.String("test-str", "", "test usage")
+	os.Args = []string{"ec2-instance-selector", "--test-str", "somevalue", "--this-should-stay", "valuetostay"}
+	newArgs := removeIntersectingArgs(flagSet)
+	h.Assert(t, len(newArgs) == 3, "NewArgs should only include the bin name and a flag + input after removing intersections")
+}
+
+func TestRemoveIntersectingArgs_ShorthandArg(t *testing.T) {
+	flagSet := pflag.NewFlagSet("test-flag-set", pflag.ContinueOnError)
+	flagSet.StringP("test-str", "t", "", "test usage")
+	os.Args = []string{"ec2-instance-selector", "--test-str", "somevalue", "--this-should-stay", "valuetostay", "-t", "test"}
+	newArgs := removeIntersectingArgs(flagSet)
+	h.Assert(t, len(newArgs) == 3, "NewArgs should only include the bin name and a flag + input after removing intersections")
+}

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -1,0 +1,244 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cli_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/aws/amazon-ec2-instance-selector/pkg/cli"
+	h "github.com/aws/amazon-ec2-instance-selector/pkg/test"
+)
+
+const (
+	maxInt = int(^uint(0) >> 1)
+)
+
+// Helpers
+
+func getTestCLI() cli.CommandLineInterface {
+	return cli.New("test", "test short usage", "test long usage", "test examples")
+}
+
+// Tests
+
+func TestValidateFlags(t *testing.T) {
+	// Nil validator should succeed validation
+	cli := getTestCLI()
+	flagName := "test-flag"
+	cli.StringFlag(flagName, nil, nil, "Test String w/o validation", nil)
+	err := cli.ValidateFlags()
+	h.Ok(t, err)
+
+	// Validator which returns nil error should succeed validation
+	cli = getTestCLI()
+	flagName = "test-flag"
+	cli.StringFlag(flagName, nil, nil, "Test String w/ successful validation", func(val interface{}) error {
+		return nil
+	})
+	err = cli.ValidateFlags()
+	h.Ok(t, err)
+
+	// Validator which returns error should fail validation
+	cli = getTestCLI()
+	cli.StringFlag(flagName, nil, nil, "Test String w/ validation failure", func(val interface{}) error {
+		return fmt.Errorf("validation failed")
+	})
+	err = cli.ValidateFlags()
+	h.Nok(t, err)
+}
+
+func TestParseFlags(t *testing.T) {
+	cli := getTestCLI()
+	flagName := "test-flag"
+	flagArg := fmt.Sprintf("--%s", flagName)
+	cli.StringFlag(flagName, nil, nil, "Test String w/o validation", nil)
+	os.Args = []string{"ec2-instance-selector", flagArg, "test"}
+	flags, err := cli.ParseFlags()
+	h.Ok(t, err)
+	flagOutput := flags[flagName].(*string)
+	h.Assert(t, *flagOutput == "test", "Flag %s should have been parsed", flagArg)
+}
+
+func TestParseFlags_IntRange(t *testing.T) {
+	flagName := "test-flag"
+	flagMinArg := fmt.Sprintf("%s-%s", flagName, "min")
+	flagMaxArg := fmt.Sprintf("%s-%s", flagName, "max")
+	flagArg := fmt.Sprintf("--%s", flagName)
+
+	// Root set Min and Max to the same val
+	cli := getTestCLI()
+	cli.IntMinMaxRangeFlags(flagName, nil, nil, "Test")
+	os.Args = []string{"ec2-instance-selector", flagArg, "5"}
+	flags, err := cli.ParseFlags()
+	h.Ok(t, err)
+	flagMinOutput := flags[flagMinArg].(*int)
+	flagMaxOutput := flags[flagMaxArg].(*int)
+	h.Assert(t, *flagMinOutput == 5 && *flagMaxOutput == 5, "Flag %s min and max should have been parsed to the same number", flagArg)
+
+	// Min is set to a val and max is set to maxInt
+	cli = getTestCLI()
+	cli.IntMinMaxRangeFlags(flagName, nil, nil, "Test")
+	os.Args = []string{"ec2-instance-selector", "--" + flagMinArg, "5"}
+	flags, err = cli.ParseFlags()
+	h.Ok(t, err)
+	flagMinOutput = flags[flagMinArg].(*int)
+	flagMaxOutput = flags[flagMaxArg].(*int)
+	h.Assert(t, *flagMinOutput == 5 && *flagMaxOutput == maxInt, "Flag %s min should have been parsed from cmdline and max set to maxInt", flagArg)
+
+	// Max is set to a val and min is set to 0
+	cli = getTestCLI()
+	cli.IntMinMaxRangeFlags(flagName, nil, nil, "Test")
+	os.Args = []string{"ec2-instance-selector", "--" + flagMaxArg, "50"}
+	flags, err = cli.ParseFlags()
+	h.Ok(t, err)
+	flagMinOutput = flags[flagMinArg].(*int)
+	flagMaxOutput = flags[flagMaxArg].(*int)
+	h.Assert(t, *flagMinOutput == 0 && *flagMaxOutput == 50, "Flag %s max should have been parsed from cmdline and min set to 0", flagArg)
+
+	// Min and Max are set to separate values
+	cli = getTestCLI()
+	cli.IntMinMaxRangeFlags(flagName, nil, nil, "Test")
+	os.Args = []string{"ec2-instance-selector", "--" + flagMinArg, "10", "--" + flagMaxArg, "500"}
+	flags, err = cli.ParseFlags()
+	h.Ok(t, err)
+	flagMinOutput = flags[flagMinArg].(*int)
+	flagMaxOutput = flags[flagMaxArg].(*int)
+	h.Assert(t, *flagMinOutput == 10 && *flagMaxOutput == 500, "Flag %s max should have been parsed from cmdline and min set to 0", flagArg)
+}
+
+func TestParseFlags_IntRangeErr(t *testing.T) {
+	cli := getTestCLI()
+	flagName := "test-flag"
+	flagArg := fmt.Sprintf("--%s", flagName)
+	cli.IntMinMaxRangeFlags(flagName, nil, nil, "Test")
+	os.Args = []string{"ec2-instance-selector", flagArg, "1", flagArg + "-min", "1", flagArg + "-max", "2"}
+	_, err := cli.ParseFlags()
+	h.Nok(t, err)
+}
+
+func TestParseFlags_RootErr(t *testing.T) {
+	cli := getTestCLI()
+	os.Args = []string{"ec2-instance-selector", "--test", "test"}
+	_, err := cli.ParseFlags()
+	h.Nok(t, err)
+}
+
+func TestParseFlags_SuiteErr(t *testing.T) {
+	cli := getTestCLI()
+	cli.SuiteBoolFlag("test", nil, nil, "")
+	os.Args = []string{"ec2-instance-selector", "-----test"}
+	_, err := cli.ParseFlags()
+	h.Nok(t, err)
+}
+
+func TestParseFlags_SuiteFlags(t *testing.T) {
+	cli := getTestCLI()
+	flagName := "test-flag"
+	flagArg := fmt.Sprintf("--%s", flagName)
+	cli.SuiteBoolFlag(flagName, nil, nil, "Test Suite Flag")
+	os.Args = []string{"ec2-instance-selector", flagArg}
+	flags, err := cli.ParseFlags()
+	h.Ok(t, err)
+	flagOutput := flags[flagName].(*bool)
+	h.Assert(t, *flagOutput == true, "Suite Flag %s should have been parsed", flagArg)
+}
+
+func TestParseFlags_ConfigFlags(t *testing.T) {
+	cli := getTestCLI()
+	flagName := "test-flag"
+	flagArg := fmt.Sprintf("--%s", flagName)
+	cli.ConfigBoolFlag(flagName, nil, nil, "Test Config Flag")
+	os.Args = []string{"ec2-instance-selector", flagArg}
+	flags, err := cli.ParseFlags()
+	h.Ok(t, err)
+	flagOutput := flags[flagName].(*bool)
+	h.Assert(t, *flagOutput == true, "Config Flag %s should have been parsed", flagArg)
+}
+
+func TestParseFlags_AllTypes(t *testing.T) {
+	cli := getTestCLI()
+	flagName := "test-flag"
+	configName := flagName + "-config"
+	suiteName := flagName + "-suite"
+	flagArg := fmt.Sprintf("--%s", flagName)
+	configArg := fmt.Sprintf("--%s", configName)
+	suiteArg := fmt.Sprintf("--%s", suiteName)
+
+	cli.BoolFlag(flagName, nil, nil, "Test Filter Flag")
+	cli.ConfigBoolFlag(configName, nil, nil, "Test Config Flag")
+	cli.SuiteBoolFlag(suiteName, nil, nil, "Test Suite Flag")
+	os.Args = []string{"ec2-instance-selector", flagArg, configArg, suiteArg}
+	flags, err := cli.ParseFlags()
+	h.Ok(t, err)
+	flagOutput := flags[flagName].(*bool)
+	configOutput := flags[configName].(*bool)
+	suiteOutput := flags[suiteName].(*bool)
+	h.Assert(t, *flagOutput && *configOutput && *suiteOutput, "Filter, Config, and Sutie Flags %s should have been parsed", flagArg)
+}
+
+func TestParseFlags_UntouchedFlags(t *testing.T) {
+	cli := getTestCLI()
+	flagName := "test-flag"
+	flagArg := fmt.Sprintf("--%s", flagName)
+
+	cli.BoolFlag(flagName, nil, nil, "Test Filter Flag")
+	os.Args = []string{"ec2-instance-selector"}
+	flags, err := cli.ParseFlags()
+	h.Ok(t, err)
+	val, ok := flags[flagName]
+	h.Assert(t, ok, "Flag %s should exist in flags map", flagArg)
+	h.Assert(t, val == nil, "Flag %s should be set to nil when not explicitly set", flagArg)
+}
+
+func TestParseFlags_UntouchedFlagsAllTypes(t *testing.T) {
+	cli := getTestCLI()
+	flagName := "test-flag"
+	ratioName := flagName + "-ratio"
+	configName := flagName + "-config"
+	suiteName := flagName + "-suite"
+	flagArg := fmt.Sprintf("--%s", flagName)
+	ratioArg := fmt.Sprintf("--%s", ratioName)
+	configArg := fmt.Sprintf("--%s", configName)
+	suiteArg := fmt.Sprintf("--%s", suiteName)
+
+	cli.IntFlag(flagName, nil, nil, "Test Filter Flag")
+	cli.RatioFlag(ratioName, nil, nil, "Test Ratio Flag")
+	cli.ConfigStringFlag(configName, nil, nil, "Test Config Flag", nil)
+	cli.SuiteBoolFlag(suiteName, nil, nil, "Test Suite Flag")
+
+	os.Args = []string{"ec2-instance-selector"}
+	flags, err := cli.ParseFlags()
+	h.Ok(t, err)
+	val, ok := flags[flagName]
+	ratioVal, ratioOk := flags[ratioName]
+	configVal, configOk := flags[configName]
+	suiteVal, suiteOk := flags[suiteName]
+	h.Assert(t, ok && ratioOk && configOk && suiteOk, "Flags %s, %s, %s should exist for all types in flags map", flagArg, ratioArg, configArg, suiteArg)
+	h.Assert(t, val == nil && ratioVal == nil && configVal == nil && suiteVal == nil,
+		"Flag %s, %s, %s should be set to nil when not explicitly set", flagArg, ratioArg, configArg, suiteArg)
+}
+
+func TestParseAndValidateFlags_Err(t *testing.T) {
+	cli := getTestCLI()
+	flagName := "test-flag"
+	flagArg := fmt.Sprintf("--%s", flagName)
+	flagMin := flagArg + "-min"
+	flagMax := flagArg + "-max"
+	cli.IntMinMaxRangeFlags(flagName, nil, nil, "Test with validation")
+	os.Args = []string{"ec2-instance-selector", flagMin, "5", flagMax, "1"}
+	_, err := cli.ParseAndValidateFlags()
+	h.Nok(t, err)
+}

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -1,0 +1,110 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cli_test
+
+import (
+	"fmt"
+	"testing"
+
+	h "github.com/aws/amazon-ec2-instance-selector/pkg/test"
+)
+
+// Tests
+
+func TestBoolFlag(t *testing.T) {
+	cli := getTestCLI()
+	for _, flagFn := range []func(string, *string, *bool, string){cli.BoolFlag, cli.ConfigBoolFlag, cli.SuiteBoolFlag} {
+		flagName := "test-int"
+		flagFn(flagName, cli.StringMe("t"), nil, "Test Bool")
+		_, ok := cli.Flags[flagName]
+		h.Assert(t, len(cli.Flags) == 1, "Should contain 1 flag")
+		h.Assert(t, ok, "Should contain %s flag", flagName)
+
+		cli = getTestCLI()
+		cli.BoolFlag(flagName, nil, nil, "Test Bool")
+		h.Assert(t, len(cli.Flags) == 1, "Should contain 1 flag w/ no shorthand")
+		h.Assert(t, ok, "Should contain %s flag w/ no shorthand", flagName)
+	}
+}
+
+func TestIntFlag(t *testing.T) {
+	cli := getTestCLI()
+	for _, flagFn := range []func(string, *string, *int, string){cli.IntFlag, cli.ConfigIntFlag} {
+		flagName := "test-int"
+		flagFn(flagName, cli.StringMe("t"), nil, "Test Int")
+		_, ok := cli.Flags[flagName]
+		h.Assert(t, len(cli.Flags) == 1, "Should contain 1 flag")
+		h.Assert(t, ok, "Should contain %s flag", flagName)
+
+		cli = getTestCLI()
+		cli.IntFlag(flagName, nil, nil, "Test Int")
+		h.Assert(t, len(cli.Flags) == 1, "Should contain 1 flag w/ no shorthand")
+		h.Assert(t, ok, "Should contain %s flag w/ no shorthand", flagName)
+	}
+}
+
+func TestStringFlag(t *testing.T) {
+	cli := getTestCLI()
+	for _, flagFn := range []func(string, *string, *string, string, func(interface{}) error){cli.StringFlag, cli.ConfigStringFlag} {
+		flagName := "test-string"
+		flagFn(flagName, cli.StringMe("t"), nil, "Test String", nil)
+		_, ok := cli.Flags[flagName]
+		h.Assert(t, len(cli.Flags) == 1, "Should contain 1 flag")
+		h.Assert(t, ok, "Should contain %s flag", flagName)
+
+		cli = getTestCLI()
+		flagFn(flagName, cli.StringMe("t"), nil, "Test String w/ validation", func(val interface{}) error {
+			return fmt.Errorf("validation failed")
+		})
+		h.Assert(t, len(cli.Flags) == 1, "Should contain 1 flag")
+		h.Assert(t, ok, "Should contain %s flag with validation", flagName)
+
+		cli = getTestCLI()
+		flagFn(flagName, nil, nil, "Test String", nil)
+		h.Assert(t, len(cli.Flags) == 1, "Should contain 1 flag w/ no shorthand")
+		h.Assert(t, ok, "Should contain %s flag w/ no shorthand", flagName)
+	}
+}
+
+func TestRatioFlag(t *testing.T) {
+	cli := getTestCLI()
+	flagName := "test-ratio"
+	cli.RatioFlag(flagName, cli.StringMe("t"), nil, "Test Ratio")
+	_, ok := cli.Flags[flagName]
+	h.Assert(t, len(cli.Flags) == 1, "Should contain 1 flag")
+	h.Assert(t, ok, "Should contain %s flag", flagName)
+
+	cli = getTestCLI()
+	cli.RatioFlag(flagName, nil, nil, "Test Ratio")
+	h.Assert(t, len(cli.Flags) == 1, "Should contain 1 flag w/ no shorthand")
+	h.Assert(t, ok, "Should contain %s flag w/ no shorthand", flagName)
+}
+
+func TestIntMinMaxRangeFlags(t *testing.T) {
+	cli := getTestCLI()
+	flagName := "test-int-min-max-range"
+	cli.IntMinMaxRangeFlags(flagName, cli.StringMe("t"), nil, "Test Min Max Range")
+	_, ok := cli.Flags[flagName]
+	_, minOk := cli.Flags[flagName+"-min"]
+	_, maxOk := cli.Flags[flagName+"-max"]
+	h.Assert(t, len(cli.Flags) == 3, "Should contain 3 flags")
+	h.Assert(t, ok, "Should contain %s flag", flagName)
+	h.Assert(t, minOk, "Should contain %s flag", flagName)
+	h.Assert(t, maxOk, "Should contain %s flag", flagName)
+
+	cli = getTestCLI()
+	cli.IntMinMaxRangeFlags(flagName, nil, nil, "Test Min Max Range")
+	h.Assert(t, len(cli.Flags) == 3, "Should contain 3 flags w/ no shorthand")
+	h.Assert(t, ok, "Should contain %s flag w/ no shorthand", flagName)
+}

--- a/pkg/cli/types.go
+++ b/pkg/cli/types.go
@@ -46,6 +46,7 @@ Global Flags:
 {{end}}`
 )
 
+// validator defines the function for providing validation on a flag
 type validator = func(val interface{}) error
 
 // CommandLineInterface is a type to group CLI funcs and state

--- a/pkg/cli/types_test.go
+++ b/pkg/cli/types_test.go
@@ -1,0 +1,88 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package cli_test
+
+import (
+	"testing"
+
+	"github.com/aws/amazon-ec2-instance-selector/pkg/selector"
+	h "github.com/aws/amazon-ec2-instance-selector/pkg/test"
+)
+
+// Tests
+
+func TestBoolMe(t *testing.T) {
+	cli := getTestCLI()
+	boolTrue := true
+	val := cli.BoolMe(boolTrue)
+	h.Assert(t, *val == true, "Should return true from passed in value bool")
+	val = cli.BoolMe(&boolTrue)
+	h.Assert(t, *val == true, "Should return true from passed in pointer bool")
+	val = cli.BoolMe(7)
+	h.Assert(t, val == nil, "Should return nil from other data type passed in")
+	val = cli.BoolMe(nil)
+	h.Assert(t, val == nil, "Should return nil if nil is passed in")
+}
+
+func TestStringMe(t *testing.T) {
+	cli := getTestCLI()
+	stringVal := "test"
+	val := cli.StringMe(stringVal)
+	h.Assert(t, *val == stringVal, "Should return %s from passed in string value", stringVal)
+	val = cli.StringMe(&stringVal)
+	h.Assert(t, *val == stringVal, "Should return %s from passed in string pointer", stringVal)
+	val = cli.StringMe(7)
+	h.Assert(t, val == nil, "Should return nil from other data type passed in")
+	val = cli.StringMe(nil)
+	h.Assert(t, val == nil, "Should return nil if nil is passed in")
+}
+
+func TestIntMe(t *testing.T) {
+	cli := getTestCLI()
+	intVal := 10
+	val := cli.IntMe(intVal)
+	h.Assert(t, *val == intVal, "Should return %s from passed in int value", intVal)
+	val = cli.IntMe(&intVal)
+	h.Assert(t, *val == intVal, "Should return %s from passed in int pointer", intVal)
+	val = cli.IntMe(true)
+	h.Assert(t, val == nil, "Should return nil from other data type passed in")
+	val = cli.IntMe(nil)
+	h.Assert(t, val == nil, "Should return nil if nil is passed in")
+}
+
+func TestFloat64Me(t *testing.T) {
+	cli := getTestCLI()
+	fVal := 10.01
+	val := cli.Float64Me(fVal)
+	h.Assert(t, *val == fVal, "Should return %s from passed in float64 value", fVal)
+	val = cli.Float64Me(&fVal)
+	h.Assert(t, *val == fVal, "Should return %s from passed in float64 pointer", fVal)
+	val = cli.Float64Me(true)
+	h.Assert(t, val == nil, "Should return nil from other data type passed in")
+	val = cli.Float64Me(nil)
+	h.Assert(t, val == nil, "Should return nil if nil is passed in")
+}
+
+func TestIntRangeMe(t *testing.T) {
+	cli := getTestCLI()
+	intRangeVal := selector.IntRangeFilter{LowerBound: 1, UpperBound: 2}
+	val := cli.IntRangeMe(intRangeVal)
+	h.Assert(t, *val == intRangeVal, "Should return %s from passed in int range value", intRangeVal)
+	val = cli.IntRangeMe(&intRangeVal)
+	h.Assert(t, *val == intRangeVal, "Should return %s from passed in range pointer", intRangeVal)
+	val = cli.IntRangeMe(true)
+	h.Assert(t, val == nil, "Should return nil from other data type passed in")
+	val = cli.IntRangeMe(nil)
+	h.Assert(t, val == nil, "Should return nil if nil is passed in")
+}

--- a/pkg/test/helpers.go
+++ b/pkg/test/helpers.go
@@ -39,6 +39,15 @@ func Ok(tb testing.TB, err error) {
 	}
 }
 
+// Nok fails the test if an err is nil.
+func Nok(tb testing.TB, err error) {
+	if err == nil {
+		_, file, line, _ := runtime.Caller(1)
+		fmt.Printf("\033[31m%s:%d: unexpected success \033[39m\n\n", filepath.Base(file), line)
+		tb.FailNow()
+	}
+}
+
 // Equals fails the test if exp is not equal to act.
 func Equals(tb testing.TB, exp, act interface{}) {
 	if !reflect.DeepEqual(exp, act) {


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
There were some bugs in the CLI parsing logic. Those bugs have been squashed and unit test coverage added so that they never break again :) 

Specifically, removeIntersectingArgs() was not working properly. This function is used to handle multiple flagSets with proper error handling at a global level. This caused issues parsing shorthand args on the CLI, resulting in panics.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
