### PR TITLE
support the aggregate instance-type-base filter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/aws/amazon-ec2-instance-selector
 go 1.14
 
 require (
-	github.com/aws/aws-sdk-go v1.29.33
+	github.com/aws/aws-sdk-go v1.31.12
 	github.com/ghodss/yaml v1.0.0
 	github.com/hashicorp/hcl v1.0.0
 	github.com/spf13/cobra v0.0.7

--- a/go.sum
+++ b/go.sum
@@ -7,6 +7,8 @@ github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5
 github.com/aws/aws-sdk-go v1.29.33 h1:WP85+WHalTFQR2wYp5xR2sjiVAZXew2bBQXGU1QJBXI=
 github.com/aws/aws-sdk-go v1.29.33/go.mod h1:1KvfttTE3SPKMpo8g2c6jL3ZKfXtFvKscTgahTma5Xg=
 github.com/aws/aws-sdk-go v1.30.26 h1:wP0N6DBb/3EyHTtWNz4jzgGVi1l290zoFGfu4HFGeM0=
+github.com/aws/aws-sdk-go v1.31.12 h1:SxRRGyhlCagI0DYkhOg+FgdXGXzRTE3vEX/gsgFaiKQ=
+github.com/aws/aws-sdk-go v1.31.12/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+CedLV8=
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
@@ -52,6 +54,8 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
+github.com/jmespath/go-jmespath v0.3.0 h1:OS12ieG61fsCg5+qLJ+SsW9NicxNkg3b25OyT2yCeUc=
+github.com/jmespath/go-jmespath v0.3.0/go.mod h1:9QtRXoHjLGCJ5IBSaohpXITPlowMeeYCZ7fLUTSywik=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
@@ -106,6 +110,7 @@ github.com/stretchr/objx v0.1.1/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0 h1:2E4SXV/wtOkTonXsotYi4li6zVWxYlZuYNCXe9XRJyk=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
+github.com/stretchr/testify v1.5.1/go.mod h1:5W2xD1RspED5o8YsWQXVCued0rvSQ+mT+I5cxcmMvtA=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20190109142713-0ad062ec5ee5/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGrc=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=

--- a/pkg/selector/selector.go
+++ b/pkg/selector/selector.go
@@ -66,6 +66,11 @@ const (
 	currentGeneration      = "currentGeneration"
 	networkInterfaces      = "networkInterfaces"
 	networkPerformance     = "networkPerformance"
+
+	// AggregateLowPercentile is the default lower percentile for resource ranges on similar instance type comparisons
+	AggregateLowPercentile = 0.8
+	// AggregateHighPercentile is the default upper percentile for resource ranges on similar instance type comparisons
+	AggregateHighPercentile = 1.2
 )
 
 // New creates an instance of Selector provided an aws session
@@ -119,9 +124,57 @@ func (itf Selector) truncateResults(maxResults *int, instanceTypeInfoSlice []*ec
 	return instanceTypeInfoSlice[0:upperIndex]
 }
 
+// AggregateFilterTransform takes higher level filters which are used to affect multiple raw filters in an opinionated way.
+func (itf Selector) AggregateFilterTransform(filters Filters, lowerPercentile float64, upperPercentile float64) (Filters, error) {
+	if filters.InstanceTypeBase != nil {
+		instanceTypesOutput, err := itf.EC2.DescribeInstanceTypes(&ec2.DescribeInstanceTypesInput{
+			InstanceTypes: []*string{filters.InstanceTypeBase},
+		})
+		if err != nil {
+			return filters, err
+		}
+		if len(instanceTypesOutput.InstanceTypes) == 0 {
+			return filters, fmt.Errorf("error instance type %s is not a valid instance type", *filters.InstanceTypeBase)
+		}
+		instanceTypeInfo := instanceTypesOutput.InstanceTypes[0]
+		if filters.BareMetal == nil {
+			filters.BareMetal = instanceTypeInfo.BareMetal
+		}
+		if filters.CPUArchitecture == nil {
+			filters.CPUArchitecture = instanceTypeInfo.ProcessorInfo.SupportedArchitectures[0]
+		}
+		if filters.Fpga == nil {
+			isFpgaSupported := instanceTypeInfo.FpgaInfo != nil
+			filters.Fpga = &isFpgaSupported
+		}
+		if filters.GpusRange == nil {
+			if instanceTypeInfo.GpuInfo != nil {
+				gpuCount := int(*getTotalGpusCount(instanceTypeInfo.GpuInfo))
+				filters.GpusRange = &IntRangeFilter{LowerBound: gpuCount, UpperBound: gpuCount}
+			}
+		}
+		if filters.MemoryRange == nil {
+			lowerBound := int(float64(*instanceTypeInfo.MemoryInfo.SizeInMiB) * lowerPercentile)
+			upperBound := int(float64(*instanceTypeInfo.MemoryInfo.SizeInMiB) * upperPercentile)
+			filters.MemoryRange = &IntRangeFilter{LowerBound: lowerBound, UpperBound: upperBound}
+		}
+		if filters.VCpusRange == nil {
+			lowerBound := int(float64(*instanceTypeInfo.VCpuInfo.DefaultVCpus) * lowerPercentile)
+			upperBound := int(float64(*instanceTypeInfo.VCpuInfo.DefaultVCpus) * upperPercentile)
+			filters.VCpusRange = &IntRangeFilter{LowerBound: lowerBound, UpperBound: upperBound}
+		}
+		filters.InstanceTypeBase = nil
+	}
+	return filters, nil
+}
+
 // rawFilter accepts a Filters struct which is used to select the available instance types
 // matching the criteria within Filters and returns the detailed specs of matching instance types
 func (itf Selector) rawFilter(filters Filters) ([]*ec2.InstanceTypeInfo, error) {
+	filters, err := itf.AggregateFilterTransform(filters, AggregateLowPercentile, AggregateHighPercentile)
+	if err != nil {
+		return nil, err
+	}
 	var location string
 	if filters.AvailabilityZone != nil {
 		location = *filters.AvailabilityZone

--- a/pkg/selector/types.go
+++ b/pkg/selector/types.go
@@ -126,4 +126,7 @@ type Filters struct {
 
 	// VcpusToMemoryRatio is a ratio of vcpus to memory expressed as a floating point
 	VCpusToMemoryRatio *float64
+
+	// InstanceTypeBase is a base instance type which is used to retrieve similarly spec'd instance types
+	InstanceTypeBase *string
 }

--- a/test/static/DescribeInstanceTypes/c4_large.json
+++ b/test/static/DescribeInstanceTypes/c4_large.json
@@ -1,0 +1,67 @@
+{
+    "InstanceTypes": [
+        {
+            "AutoRecoverySupported": true,
+            "BareMetal": false,
+            "BurstablePerformanceSupported": false,
+            "CurrentGeneration": true,
+            "DedicatedHostsSupported": true,
+            "EbsInfo": {
+                "EbsOptimizedSupport": "default",
+                "EncryptionSupport": "supported"
+            },
+            "FpgaInfo": null,
+            "FreeTierEligible": false,
+            "GpuInfo": null,
+            "HibernationSupported": true,
+            "Hypervisor": "xen",
+            "InferenceAcceleratorInfo": null,
+            "InstanceStorageInfo": null,
+            "InstanceStorageSupported": false,
+            "InstanceType": "c4.large",
+            "MemoryInfo": {
+                "SizeInMiB": 3840
+            },
+            "NetworkInfo": {
+                "EnaSupport": "unsupported",
+                "Ipv4AddressesPerInterface": 10,
+                "Ipv6AddressesPerInterface": 10,
+                "Ipv6Supported": true,
+                "MaximumNetworkInterfaces": 3,
+                "NetworkPerformance": "Moderate"
+            },
+            "PlacementGroupInfo": {
+                "SupportedStrategies": [
+                    "cluster",
+                    "partition",
+                    "spread"
+                ]
+            },
+            "ProcessorInfo": {
+                "SupportedArchitectures": [
+                    "x86_64"
+                ],
+                "SustainedClockSpeedInGhz": 2.9
+            },
+            "SupportedRootDeviceTypes": [
+                "ebs"
+            ],
+            "SupportedUsageClasses": [
+                "on-demand",
+                "spot"
+            ],
+            "VCpuInfo": {
+                "DefaultCores": 1,
+                "DefaultThreadsPerCore": 2,
+                "DefaultVCpus": 2,
+                "ValidCores": [
+                    1
+                ],
+                "ValidThreadsPerCore": [
+                    1,
+                    2
+                ]
+            }
+        }
+    ]
+}

--- a/test/static/DescribeInstanceTypes/empty.json
+++ b/test/static/DescribeInstanceTypes/empty.json
@@ -1,0 +1,3 @@
+{
+    "InstanceTypes": []
+}

--- a/test/static/DescribeInstanceTypesPages/25_instances.json
+++ b/test/static/DescribeInstanceTypesPages/25_instances.json
@@ -1,0 +1,1736 @@
+{
+    "InstanceTypes": [
+    {
+        "AutoRecoverySupported": true,
+        "BareMetal": false,
+        "BurstablePerformanceSupported": false,
+        "CurrentGeneration": true,
+        "DedicatedHostsSupported": true,
+        "EbsInfo": {
+            "EbsOptimizedSupport": "default",
+            "EncryptionSupport": "supported"
+        },
+        "FpgaInfo": null,
+        "FreeTierEligible": false,
+        "GpuInfo": null,
+        "HibernationSupported": false,
+        "Hypervisor": "nitro",
+        "InferenceAcceleratorInfo": null,
+        "InstanceStorageInfo": null,
+        "InstanceStorageSupported": false,
+        "InstanceType": "a1.2xlarge",
+        "MemoryInfo": {
+            "SizeInMiB": 16384
+        },
+        "NetworkInfo": {
+            "EnaSupport": "required",
+            "Ipv4AddressesPerInterface": 15,
+            "Ipv6AddressesPerInterface": 15,
+            "Ipv6Supported": true,
+            "MaximumNetworkInterfaces": 4,
+            "NetworkPerformance": "Up to 10 Gigabit"
+        },
+        "PlacementGroupInfo": {
+            "SupportedStrategies": [
+                "cluster",
+                "partition",
+                "spread"
+            ]
+        },
+        "ProcessorInfo": {
+            "SupportedArchitectures": [
+                "arm64"
+            ],
+            "SustainedClockSpeedInGhz": 2.3
+        },
+        "SupportedRootDeviceTypes": [
+            "ebs"
+        ],
+        "SupportedUsageClasses": [
+            "on-demand"
+        ],
+        "VCpuInfo": {
+            "DefaultCores": 8,
+            "DefaultThreadsPerCore": 1,
+            "DefaultVCpus": 8,
+            "ValidCores": [
+                8
+            ],
+            "ValidThreadsPerCore": [
+                1
+            ]
+        }
+    },
+    {
+        "AutoRecoverySupported": true,
+        "BareMetal": false,
+        "BurstablePerformanceSupported": false,
+        "CurrentGeneration": true,
+        "DedicatedHostsSupported": true,
+        "EbsInfo": {
+            "EbsOptimizedSupport": "default",
+            "EncryptionSupport": "supported"
+        },
+        "FpgaInfo": null,
+        "FreeTierEligible": false,
+        "GpuInfo": null,
+        "HibernationSupported": false,
+        "Hypervisor": "nitro",
+        "InferenceAcceleratorInfo": null,
+        "InstanceStorageInfo": null,
+        "InstanceStorageSupported": false,
+        "InstanceType": "a1.4xlarge",
+        "MemoryInfo": {
+            "SizeInMiB": 32768
+        },
+        "NetworkInfo": {
+            "EnaSupport": "required",
+            "Ipv4AddressesPerInterface": 30,
+            "Ipv6AddressesPerInterface": 30,
+            "Ipv6Supported": true,
+            "MaximumNetworkInterfaces": 8,
+            "NetworkPerformance": "Up to 10 Gigabit"
+        },
+        "PlacementGroupInfo": {
+            "SupportedStrategies": [
+                "cluster",
+                "partition",
+                "spread"
+            ]
+        },
+        "ProcessorInfo": {
+            "SupportedArchitectures": [
+                "arm64"
+            ],
+            "SustainedClockSpeedInGhz": 2.3
+        },
+        "SupportedRootDeviceTypes": [
+            "ebs"
+        ],
+        "SupportedUsageClasses": [
+            "on-demand"
+        ],
+        "VCpuInfo": {
+            "DefaultCores": 16,
+            "DefaultThreadsPerCore": 1,
+            "DefaultVCpus": 16,
+            "ValidCores": [
+                16
+            ],
+            "ValidThreadsPerCore": [
+                1
+            ]
+        }
+    },
+    {
+        "AutoRecoverySupported": true,
+        "BareMetal": false,
+        "BurstablePerformanceSupported": false,
+        "CurrentGeneration": true,
+        "DedicatedHostsSupported": true,
+        "EbsInfo": {
+            "EbsOptimizedSupport": "default",
+            "EncryptionSupport": "supported"
+        },
+        "FpgaInfo": null,
+        "FreeTierEligible": false,
+        "GpuInfo": null,
+        "HibernationSupported": false,
+        "Hypervisor": "nitro",
+        "InferenceAcceleratorInfo": null,
+        "InstanceStorageInfo": null,
+        "InstanceStorageSupported": false,
+        "InstanceType": "a1.large",
+        "MemoryInfo": {
+            "SizeInMiB": 4096
+        },
+        "NetworkInfo": {
+            "EnaSupport": "required",
+            "Ipv4AddressesPerInterface": 10,
+            "Ipv6AddressesPerInterface": 10,
+            "Ipv6Supported": true,
+            "MaximumNetworkInterfaces": 3,
+            "NetworkPerformance": "Up to 10 Gigabit"
+        },
+        "PlacementGroupInfo": {
+            "SupportedStrategies": [
+                "cluster",
+                "partition",
+                "spread"
+            ]
+        },
+        "ProcessorInfo": {
+            "SupportedArchitectures": [
+                "arm64"
+            ],
+            "SustainedClockSpeedInGhz": 2.3
+        },
+        "SupportedRootDeviceTypes": [
+            "ebs"
+        ],
+        "SupportedUsageClasses": [
+            "on-demand"
+        ],
+        "VCpuInfo": {
+            "DefaultCores": 2,
+            "DefaultThreadsPerCore": 1,
+            "DefaultVCpus": 2,
+            "ValidCores": [
+                2
+            ],
+            "ValidThreadsPerCore": [
+                1
+            ]
+        }
+    },
+    {
+        "AutoRecoverySupported": true,
+        "BareMetal": false,
+        "BurstablePerformanceSupported": false,
+        "CurrentGeneration": true,
+        "DedicatedHostsSupported": true,
+        "EbsInfo": {
+            "EbsOptimizedSupport": "default",
+            "EncryptionSupport": "supported"
+        },
+        "FpgaInfo": null,
+        "FreeTierEligible": false,
+        "GpuInfo": null,
+        "HibernationSupported": false,
+        "Hypervisor": "nitro",
+        "InferenceAcceleratorInfo": null,
+        "InstanceStorageInfo": null,
+        "InstanceStorageSupported": false,
+        "InstanceType": "a1.medium",
+        "MemoryInfo": {
+            "SizeInMiB": 2048
+        },
+        "NetworkInfo": {
+            "EnaSupport": "required",
+            "Ipv4AddressesPerInterface": 4,
+            "Ipv6AddressesPerInterface": 4,
+            "Ipv6Supported": true,
+            "MaximumNetworkInterfaces": 2,
+            "NetworkPerformance": "Up to 10 Gigabit"
+        },
+        "PlacementGroupInfo": {
+            "SupportedStrategies": [
+                "cluster",
+                "partition",
+                "spread"
+            ]
+        },
+        "ProcessorInfo": {
+            "SupportedArchitectures": [
+                "arm64"
+            ],
+            "SustainedClockSpeedInGhz": 2.3
+        },
+        "SupportedRootDeviceTypes": [
+            "ebs"
+        ],
+        "SupportedUsageClasses": [
+            "on-demand"
+        ],
+        "VCpuInfo": {
+            "DefaultCores": 1,
+            "DefaultThreadsPerCore": 1,
+            "DefaultVCpus": 1,
+            "ValidCores": [
+                1
+            ],
+            "ValidThreadsPerCore": [
+                1
+            ]
+        }
+    },
+    {
+        "AutoRecoverySupported": true,
+        "BareMetal": true,
+        "BurstablePerformanceSupported": false,
+        "CurrentGeneration": true,
+        "DedicatedHostsSupported": true,
+        "EbsInfo": {
+            "EbsOptimizedSupport": "default",
+            "EncryptionSupport": "supported"
+        },
+        "FpgaInfo": null,
+        "FreeTierEligible": false,
+        "GpuInfo": null,
+        "HibernationSupported": false,
+        "Hypervisor": null,
+        "InferenceAcceleratorInfo": null,
+        "InstanceStorageInfo": null,
+        "InstanceStorageSupported": false,
+        "InstanceType": "a1.metal",
+        "MemoryInfo": {
+            "SizeInMiB": 32768
+        },
+        "NetworkInfo": {
+            "EnaSupport": "required",
+            "Ipv4AddressesPerInterface": 30,
+            "Ipv6AddressesPerInterface": 30,
+            "Ipv6Supported": true,
+            "MaximumNetworkInterfaces": 8,
+            "NetworkPerformance": "Up to 10 Gigabit"
+        },
+        "PlacementGroupInfo": {
+            "SupportedStrategies": [
+                "cluster",
+                "partition",
+                "spread"
+            ]
+        },
+        "ProcessorInfo": {
+            "SupportedArchitectures": [
+                "arm64"
+            ],
+            "SustainedClockSpeedInGhz": 2.3
+        },
+        "SupportedRootDeviceTypes": [
+            "ebs"
+        ],
+        "SupportedUsageClasses": [
+            "on-demand"
+        ],
+        "VCpuInfo": {
+            "DefaultCores": null,
+            "DefaultThreadsPerCore": null,
+            "DefaultVCpus": 16,
+            "ValidCores": null,
+            "ValidThreadsPerCore": null
+        }
+    },
+    {
+        "AutoRecoverySupported": true,
+        "BareMetal": false,
+        "BurstablePerformanceSupported": false,
+        "CurrentGeneration": true,
+        "DedicatedHostsSupported": true,
+        "EbsInfo": {
+            "EbsOptimizedSupport": "default",
+            "EncryptionSupport": "supported"
+        },
+        "FpgaInfo": null,
+        "FreeTierEligible": false,
+        "GpuInfo": null,
+        "HibernationSupported": false,
+        "Hypervisor": "nitro",
+        "InferenceAcceleratorInfo": null,
+        "InstanceStorageInfo": null,
+        "InstanceStorageSupported": false,
+        "InstanceType": "a1.xlarge",
+        "MemoryInfo": {
+            "SizeInMiB": 8192
+        },
+        "NetworkInfo": {
+            "EnaSupport": "required",
+            "Ipv4AddressesPerInterface": 15,
+            "Ipv6AddressesPerInterface": 15,
+            "Ipv6Supported": true,
+            "MaximumNetworkInterfaces": 4,
+            "NetworkPerformance": "Up to 10 Gigabit"
+        },
+        "PlacementGroupInfo": {
+            "SupportedStrategies": [
+                "cluster",
+                "partition",
+                "spread"
+            ]
+        },
+        "ProcessorInfo": {
+            "SupportedArchitectures": [
+                "arm64"
+            ],
+            "SustainedClockSpeedInGhz": 2.3
+        },
+        "SupportedRootDeviceTypes": [
+            "ebs"
+        ],
+        "SupportedUsageClasses": [
+            "on-demand"
+        ],
+        "VCpuInfo": {
+            "DefaultCores": 4,
+            "DefaultThreadsPerCore": 1,
+            "DefaultVCpus": 4,
+            "ValidCores": [
+                4
+            ],
+            "ValidThreadsPerCore": [
+                1
+            ]
+        }
+    },
+    {
+        "AutoRecoverySupported": false,
+        "BareMetal": false,
+        "BurstablePerformanceSupported": false,
+        "CurrentGeneration": false,
+        "DedicatedHostsSupported": false,
+        "EbsInfo": {
+            "EbsOptimizedSupport": "unsupported",
+            "EncryptionSupport": "unsupported"
+        },
+        "FpgaInfo": null,
+        "FreeTierEligible": false,
+        "GpuInfo": null,
+        "HibernationSupported": false,
+        "Hypervisor": "xen",
+        "InferenceAcceleratorInfo": null,
+        "InstanceStorageInfo": {
+            "Disks": [
+                {
+                    "Count": 1,
+                    "SizeInGB": 350,
+                    "Type": "hdd"
+                }
+            ],
+            "TotalSizeInGB": 350
+        },
+        "InstanceStorageSupported": true,
+        "InstanceType": "c1.medium",
+        "MemoryInfo": {
+            "SizeInMiB": 1740
+        },
+        "NetworkInfo": {
+            "EnaSupport": "unsupported",
+            "Ipv4AddressesPerInterface": 6,
+            "Ipv6AddressesPerInterface": 0,
+            "Ipv6Supported": false,
+            "MaximumNetworkInterfaces": 2,
+            "NetworkPerformance": "Moderate"
+        },
+        "PlacementGroupInfo": {
+            "SupportedStrategies": [
+                "partition",
+                "spread"
+            ]
+        },
+        "ProcessorInfo": {
+            "SupportedArchitectures": [
+                "i386",
+                "x86_64"
+            ],
+            "SustainedClockSpeedInGhz": null
+        },
+        "SupportedRootDeviceTypes": [
+            "ebs",
+            "instance-store"
+        ],
+        "SupportedUsageClasses": [
+            "on-demand"
+        ],
+        "VCpuInfo": {
+            "DefaultCores": 2,
+            "DefaultThreadsPerCore": 1,
+            "DefaultVCpus": 2,
+            "ValidCores": [
+                1,
+                2
+            ],
+            "ValidThreadsPerCore": [
+                1
+            ]
+        }
+    },
+    {
+        "AutoRecoverySupported": false,
+        "BareMetal": false,
+        "BurstablePerformanceSupported": false,
+        "CurrentGeneration": false,
+        "DedicatedHostsSupported": false,
+        "EbsInfo": {
+            "EbsOptimizedSupport": "supported",
+            "EncryptionSupport": "unsupported"
+        },
+        "FpgaInfo": null,
+        "FreeTierEligible": false,
+        "GpuInfo": null,
+        "HibernationSupported": false,
+        "Hypervisor": "xen",
+        "InferenceAcceleratorInfo": null,
+        "InstanceStorageInfo": {
+            "Disks": [
+                {
+                    "Count": 4,
+                    "SizeInGB": 420,
+                    "Type": "hdd"
+                }
+            ],
+            "TotalSizeInGB": 1680
+        },
+        "InstanceStorageSupported": true,
+        "InstanceType": "c1.xlarge",
+        "MemoryInfo": {
+            "SizeInMiB": 7168
+        },
+        "NetworkInfo": {
+            "EnaSupport": "unsupported",
+            "Ipv4AddressesPerInterface": 15,
+            "Ipv6AddressesPerInterface": 0,
+            "Ipv6Supported": false,
+            "MaximumNetworkInterfaces": 4,
+            "NetworkPerformance": "High"
+        },
+        "PlacementGroupInfo": {
+            "SupportedStrategies": [
+                "partition",
+                "spread"
+            ]
+        },
+        "ProcessorInfo": {
+            "SupportedArchitectures": [
+                "x86_64"
+            ],
+            "SustainedClockSpeedInGhz": null
+        },
+        "SupportedRootDeviceTypes": [
+            "ebs",
+            "instance-store"
+        ],
+        "SupportedUsageClasses": [
+            "on-demand"
+        ],
+        "VCpuInfo": {
+            "DefaultCores": 8,
+            "DefaultThreadsPerCore": 1,
+            "DefaultVCpus": 8,
+            "ValidCores": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+            ],
+            "ValidThreadsPerCore": [
+                1
+            ]
+        }
+    },
+    {
+        "AutoRecoverySupported": true,
+        "BareMetal": false,
+        "BurstablePerformanceSupported": false,
+        "CurrentGeneration": false,
+        "DedicatedHostsSupported": true,
+        "EbsInfo": {
+            "EbsOptimizedSupport": "supported",
+            "EncryptionSupport": "supported"
+        },
+        "FpgaInfo": null,
+        "FreeTierEligible": false,
+        "GpuInfo": null,
+        "HibernationSupported": true,
+        "Hypervisor": "xen",
+        "InferenceAcceleratorInfo": null,
+        "InstanceStorageInfo": {
+            "Disks": [
+                {
+                    "Count": 2,
+                    "SizeInGB": 80,
+                    "Type": "ssd"
+                }
+            ],
+            "TotalSizeInGB": 160
+        },
+        "InstanceStorageSupported": true,
+        "InstanceType": "c3.2xlarge",
+        "MemoryInfo": {
+            "SizeInMiB": 15360
+        },
+        "NetworkInfo": {
+            "EnaSupport": "unsupported",
+            "Ipv4AddressesPerInterface": 15,
+            "Ipv6AddressesPerInterface": 15,
+            "Ipv6Supported": true,
+            "MaximumNetworkInterfaces": 4,
+            "NetworkPerformance": "High"
+        },
+        "PlacementGroupInfo": {
+            "SupportedStrategies": [
+                "cluster",
+                "partition",
+                "spread"
+            ]
+        },
+        "ProcessorInfo": {
+            "SupportedArchitectures": [
+                "x86_64"
+            ],
+            "SustainedClockSpeedInGhz": 2.8
+        },
+        "SupportedRootDeviceTypes": [
+            "ebs",
+            "instance-store"
+        ],
+        "SupportedUsageClasses": [
+            "on-demand",
+            "spot"
+        ],
+        "VCpuInfo": {
+            "DefaultCores": 4,
+            "DefaultThreadsPerCore": 2,
+            "DefaultVCpus": 8,
+            "ValidCores": [
+                1,
+                2,
+                3,
+                4
+            ],
+            "ValidThreadsPerCore": [
+                1,
+                2
+            ]
+        }
+    },
+    {
+        "AutoRecoverySupported": true,
+        "BareMetal": false,
+        "BurstablePerformanceSupported": false,
+        "CurrentGeneration": false,
+        "DedicatedHostsSupported": true,
+        "EbsInfo": {
+            "EbsOptimizedSupport": "supported",
+            "EncryptionSupport": "supported"
+        },
+        "FpgaInfo": null,
+        "FreeTierEligible": false,
+        "GpuInfo": null,
+        "HibernationSupported": true,
+        "Hypervisor": "xen",
+        "InferenceAcceleratorInfo": null,
+        "InstanceStorageInfo": {
+            "Disks": [
+                {
+                    "Count": 2,
+                    "SizeInGB": 160,
+                    "Type": "ssd"
+                }
+            ],
+            "TotalSizeInGB": 320
+        },
+        "InstanceStorageSupported": true,
+        "InstanceType": "c3.4xlarge",
+        "MemoryInfo": {
+            "SizeInMiB": 30720
+        },
+        "NetworkInfo": {
+            "EnaSupport": "unsupported",
+            "Ipv4AddressesPerInterface": 30,
+            "Ipv6AddressesPerInterface": 30,
+            "Ipv6Supported": true,
+            "MaximumNetworkInterfaces": 8,
+            "NetworkPerformance": "High"
+        },
+        "PlacementGroupInfo": {
+            "SupportedStrategies": [
+                "cluster",
+                "partition",
+                "spread"
+            ]
+        },
+        "ProcessorInfo": {
+            "SupportedArchitectures": [
+                "x86_64"
+            ],
+            "SustainedClockSpeedInGhz": 2.8
+        },
+        "SupportedRootDeviceTypes": [
+            "ebs",
+            "instance-store"
+        ],
+        "SupportedUsageClasses": [
+            "on-demand",
+            "spot"
+        ],
+        "VCpuInfo": {
+            "DefaultCores": 8,
+            "DefaultThreadsPerCore": 2,
+            "DefaultVCpus": 16,
+            "ValidCores": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+            ],
+            "ValidThreadsPerCore": [
+                1,
+                2
+            ]
+        }
+    },
+    {
+        "AutoRecoverySupported": true,
+        "BareMetal": false,
+        "BurstablePerformanceSupported": false,
+        "CurrentGeneration": false,
+        "DedicatedHostsSupported": true,
+        "EbsInfo": {
+            "EbsOptimizedSupport": "unsupported",
+            "EncryptionSupport": "supported"
+        },
+        "FpgaInfo": null,
+        "FreeTierEligible": false,
+        "GpuInfo": null,
+        "HibernationSupported": true,
+        "Hypervisor": "xen",
+        "InferenceAcceleratorInfo": null,
+        "InstanceStorageInfo": {
+            "Disks": [
+                {
+                    "Count": 2,
+                    "SizeInGB": 320,
+                    "Type": "ssd"
+                }
+            ],
+            "TotalSizeInGB": 640
+        },
+        "InstanceStorageSupported": true,
+        "InstanceType": "c3.8xlarge",
+        "MemoryInfo": {
+            "SizeInMiB": 61440
+        },
+        "NetworkInfo": {
+            "EnaSupport": "unsupported",
+            "Ipv4AddressesPerInterface": 30,
+            "Ipv6AddressesPerInterface": 30,
+            "Ipv6Supported": true,
+            "MaximumNetworkInterfaces": 8,
+            "NetworkPerformance": "10 Gigabit"
+        },
+        "PlacementGroupInfo": {
+            "SupportedStrategies": [
+                "cluster",
+                "partition",
+                "spread"
+            ]
+        },
+        "ProcessorInfo": {
+            "SupportedArchitectures": [
+                "x86_64"
+            ],
+            "SustainedClockSpeedInGhz": 2.8
+        },
+        "SupportedRootDeviceTypes": [
+            "ebs",
+            "instance-store"
+        ],
+        "SupportedUsageClasses": [
+            "on-demand",
+            "spot"
+        ],
+        "VCpuInfo": {
+            "DefaultCores": 16,
+            "DefaultThreadsPerCore": 2,
+            "DefaultVCpus": 32,
+            "ValidCores": [
+                2,
+                4,
+                6,
+                8,
+                10,
+                12,
+                14,
+                16
+            ],
+            "ValidThreadsPerCore": [
+                1,
+                2
+            ]
+        }
+    },
+    {
+        "AutoRecoverySupported": true,
+        "BareMetal": false,
+        "BurstablePerformanceSupported": false,
+        "CurrentGeneration": false,
+        "DedicatedHostsSupported": true,
+        "EbsInfo": {
+            "EbsOptimizedSupport": "unsupported",
+            "EncryptionSupport": "supported"
+        },
+        "FpgaInfo": null,
+        "FreeTierEligible": false,
+        "GpuInfo": null,
+        "HibernationSupported": true,
+        "Hypervisor": "xen",
+        "InferenceAcceleratorInfo": null,
+        "InstanceStorageInfo": {
+            "Disks": [
+                {
+                    "Count": 2,
+                    "SizeInGB": 16,
+                    "Type": "ssd"
+                }
+            ],
+            "TotalSizeInGB": 32
+        },
+        "InstanceStorageSupported": true,
+        "InstanceType": "c3.large",
+        "MemoryInfo": {
+            "SizeInMiB": 3840
+        },
+        "NetworkInfo": {
+            "EnaSupport": "unsupported",
+            "Ipv4AddressesPerInterface": 10,
+            "Ipv6AddressesPerInterface": 10,
+            "Ipv6Supported": true,
+            "MaximumNetworkInterfaces": 3,
+            "NetworkPerformance": "Moderate"
+        },
+        "PlacementGroupInfo": {
+            "SupportedStrategies": [
+                "cluster",
+                "partition",
+                "spread"
+            ]
+        },
+        "ProcessorInfo": {
+            "SupportedArchitectures": [
+                "i386",
+                "x86_64"
+            ],
+            "SustainedClockSpeedInGhz": 2.8
+        },
+        "SupportedRootDeviceTypes": [
+            "ebs",
+            "instance-store"
+        ],
+        "SupportedUsageClasses": [
+            "on-demand",
+            "spot"
+        ],
+        "VCpuInfo": {
+            "DefaultCores": 1,
+            "DefaultThreadsPerCore": 2,
+            "DefaultVCpus": 2,
+            "ValidCores": [
+                1
+            ],
+            "ValidThreadsPerCore": [
+                1,
+                2
+            ]
+        }
+    },
+    {
+        "AutoRecoverySupported": true,
+        "BareMetal": false,
+        "BurstablePerformanceSupported": false,
+        "CurrentGeneration": false,
+        "DedicatedHostsSupported": true,
+        "EbsInfo": {
+            "EbsOptimizedSupport": "supported",
+            "EncryptionSupport": "supported"
+        },
+        "FpgaInfo": null,
+        "FreeTierEligible": false,
+        "GpuInfo": null,
+        "HibernationSupported": true,
+        "Hypervisor": "xen",
+        "InferenceAcceleratorInfo": null,
+        "InstanceStorageInfo": {
+            "Disks": [
+                {
+                    "Count": 2,
+                    "SizeInGB": 40,
+                    "Type": "ssd"
+                }
+            ],
+            "TotalSizeInGB": 80
+        },
+        "InstanceStorageSupported": true,
+        "InstanceType": "c3.xlarge",
+        "MemoryInfo": {
+            "SizeInMiB": 7680
+        },
+        "NetworkInfo": {
+            "EnaSupport": "unsupported",
+            "Ipv4AddressesPerInterface": 15,
+            "Ipv6AddressesPerInterface": 15,
+            "Ipv6Supported": true,
+            "MaximumNetworkInterfaces": 4,
+            "NetworkPerformance": "Moderate"
+        },
+        "PlacementGroupInfo": {
+            "SupportedStrategies": [
+                "cluster",
+                "partition",
+                "spread"
+            ]
+        },
+        "ProcessorInfo": {
+            "SupportedArchitectures": [
+                "x86_64"
+            ],
+            "SustainedClockSpeedInGhz": 2.8
+        },
+        "SupportedRootDeviceTypes": [
+            "ebs",
+            "instance-store"
+        ],
+        "SupportedUsageClasses": [
+            "on-demand",
+            "spot"
+        ],
+        "VCpuInfo": {
+            "DefaultCores": 2,
+            "DefaultThreadsPerCore": 2,
+            "DefaultVCpus": 4,
+            "ValidCores": [
+                1,
+                2
+            ],
+            "ValidThreadsPerCore": [
+                1,
+                2
+            ]
+        }
+    },
+    {
+        "AutoRecoverySupported": true,
+        "BareMetal": false,
+        "BurstablePerformanceSupported": false,
+        "CurrentGeneration": true,
+        "DedicatedHostsSupported": true,
+        "EbsInfo": {
+            "EbsOptimizedSupport": "default",
+            "EncryptionSupport": "supported"
+        },
+        "FpgaInfo": null,
+        "FreeTierEligible": false,
+        "GpuInfo": null,
+        "HibernationSupported": true,
+        "Hypervisor": "xen",
+        "InferenceAcceleratorInfo": null,
+        "InstanceStorageInfo": null,
+        "InstanceStorageSupported": false,
+        "InstanceType": "c4.2xlarge",
+        "MemoryInfo": {
+            "SizeInMiB": 15360
+        },
+        "NetworkInfo": {
+            "EnaSupport": "unsupported",
+            "Ipv4AddressesPerInterface": 15,
+            "Ipv6AddressesPerInterface": 15,
+            "Ipv6Supported": true,
+            "MaximumNetworkInterfaces": 4,
+            "NetworkPerformance": "High"
+        },
+        "PlacementGroupInfo": {
+            "SupportedStrategies": [
+                "cluster",
+                "partition",
+                "spread"
+            ]
+        },
+        "ProcessorInfo": {
+            "SupportedArchitectures": [
+                "x86_64"
+            ],
+            "SustainedClockSpeedInGhz": 2.9
+        },
+        "SupportedRootDeviceTypes": [
+            "ebs"
+        ],
+        "SupportedUsageClasses": [
+            "on-demand",
+            "spot"
+        ],
+        "VCpuInfo": {
+            "DefaultCores": 4,
+            "DefaultThreadsPerCore": 2,
+            "DefaultVCpus": 8,
+            "ValidCores": [
+                1,
+                2,
+                3,
+                4
+            ],
+            "ValidThreadsPerCore": [
+                1,
+                2
+            ]
+        }
+    },
+    {
+        "AutoRecoverySupported": true,
+        "BareMetal": false,
+        "BurstablePerformanceSupported": false,
+        "CurrentGeneration": true,
+        "DedicatedHostsSupported": true,
+        "EbsInfo": {
+            "EbsOptimizedSupport": "default",
+            "EncryptionSupport": "supported"
+        },
+        "FpgaInfo": null,
+        "FreeTierEligible": false,
+        "GpuInfo": null,
+        "HibernationSupported": true,
+        "Hypervisor": "xen",
+        "InferenceAcceleratorInfo": null,
+        "InstanceStorageInfo": null,
+        "InstanceStorageSupported": false,
+        "InstanceType": "c4.4xlarge",
+        "MemoryInfo": {
+            "SizeInMiB": 30720
+        },
+        "NetworkInfo": {
+            "EnaSupport": "unsupported",
+            "Ipv4AddressesPerInterface": 30,
+            "Ipv6AddressesPerInterface": 30,
+            "Ipv6Supported": true,
+            "MaximumNetworkInterfaces": 8,
+            "NetworkPerformance": "High"
+        },
+        "PlacementGroupInfo": {
+            "SupportedStrategies": [
+                "cluster",
+                "partition",
+                "spread"
+            ]
+        },
+        "ProcessorInfo": {
+            "SupportedArchitectures": [
+                "x86_64"
+            ],
+            "SustainedClockSpeedInGhz": 2.9
+        },
+        "SupportedRootDeviceTypes": [
+            "ebs"
+        ],
+        "SupportedUsageClasses": [
+            "on-demand",
+            "spot"
+        ],
+        "VCpuInfo": {
+            "DefaultCores": 8,
+            "DefaultThreadsPerCore": 2,
+            "DefaultVCpus": 16,
+            "ValidCores": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+            ],
+            "ValidThreadsPerCore": [
+                1,
+                2
+            ]
+        }
+    },
+    {
+        "AutoRecoverySupported": true,
+        "BareMetal": false,
+        "BurstablePerformanceSupported": false,
+        "CurrentGeneration": true,
+        "DedicatedHostsSupported": true,
+        "EbsInfo": {
+            "EbsOptimizedSupport": "default",
+            "EncryptionSupport": "supported"
+        },
+        "FpgaInfo": null,
+        "FreeTierEligible": false,
+        "GpuInfo": null,
+        "HibernationSupported": true,
+        "Hypervisor": "xen",
+        "InferenceAcceleratorInfo": null,
+        "InstanceStorageInfo": null,
+        "InstanceStorageSupported": false,
+        "InstanceType": "c4.8xlarge",
+        "MemoryInfo": {
+            "SizeInMiB": 61440
+        },
+        "NetworkInfo": {
+            "EnaSupport": "unsupported",
+            "Ipv4AddressesPerInterface": 30,
+            "Ipv6AddressesPerInterface": 30,
+            "Ipv6Supported": true,
+            "MaximumNetworkInterfaces": 8,
+            "NetworkPerformance": "10 Gigabit"
+        },
+        "PlacementGroupInfo": {
+            "SupportedStrategies": [
+                "cluster",
+                "partition",
+                "spread"
+            ]
+        },
+        "ProcessorInfo": {
+            "SupportedArchitectures": [
+                "x86_64"
+            ],
+            "SustainedClockSpeedInGhz": 2.9
+        },
+        "SupportedRootDeviceTypes": [
+            "ebs"
+        ],
+        "SupportedUsageClasses": [
+            "on-demand",
+            "spot"
+        ],
+        "VCpuInfo": {
+            "DefaultCores": 18,
+            "DefaultThreadsPerCore": 2,
+            "DefaultVCpus": 36,
+            "ValidCores": [
+                2,
+                4,
+                6,
+                8,
+                10,
+                12,
+                14,
+                16,
+                18
+            ],
+            "ValidThreadsPerCore": [
+                1,
+                2
+            ]
+        }
+    },
+    {
+        "AutoRecoverySupported": true,
+        "BareMetal": false,
+        "BurstablePerformanceSupported": false,
+        "CurrentGeneration": true,
+        "DedicatedHostsSupported": true,
+        "EbsInfo": {
+            "EbsOptimizedSupport": "default",
+            "EncryptionSupport": "supported"
+        },
+        "FpgaInfo": null,
+        "FreeTierEligible": false,
+        "GpuInfo": null,
+        "HibernationSupported": true,
+        "Hypervisor": "xen",
+        "InferenceAcceleratorInfo": null,
+        "InstanceStorageInfo": null,
+        "InstanceStorageSupported": false,
+        "InstanceType": "c4.large",
+        "MemoryInfo": {
+            "SizeInMiB": 3840
+        },
+        "NetworkInfo": {
+            "EnaSupport": "unsupported",
+            "Ipv4AddressesPerInterface": 10,
+            "Ipv6AddressesPerInterface": 10,
+            "Ipv6Supported": true,
+            "MaximumNetworkInterfaces": 3,
+            "NetworkPerformance": "Moderate"
+        },
+        "PlacementGroupInfo": {
+            "SupportedStrategies": [
+                "cluster",
+                "partition",
+                "spread"
+            ]
+        },
+        "ProcessorInfo": {
+            "SupportedArchitectures": [
+                "x86_64"
+            ],
+            "SustainedClockSpeedInGhz": 2.9
+        },
+        "SupportedRootDeviceTypes": [
+            "ebs"
+        ],
+        "SupportedUsageClasses": [
+            "on-demand",
+            "spot"
+        ],
+        "VCpuInfo": {
+            "DefaultCores": 1,
+            "DefaultThreadsPerCore": 2,
+            "DefaultVCpus": 2,
+            "ValidCores": [
+                1
+            ],
+            "ValidThreadsPerCore": [
+                1,
+                2
+            ]
+        }
+    },
+    {
+        "AutoRecoverySupported": true,
+        "BareMetal": false,
+        "BurstablePerformanceSupported": false,
+        "CurrentGeneration": true,
+        "DedicatedHostsSupported": true,
+        "EbsInfo": {
+            "EbsOptimizedSupport": "default",
+            "EncryptionSupport": "supported"
+        },
+        "FpgaInfo": null,
+        "FreeTierEligible": false,
+        "GpuInfo": null,
+        "HibernationSupported": true,
+        "Hypervisor": "xen",
+        "InferenceAcceleratorInfo": null,
+        "InstanceStorageInfo": null,
+        "InstanceStorageSupported": false,
+        "InstanceType": "c4.xlarge",
+        "MemoryInfo": {
+            "SizeInMiB": 7680
+        },
+        "NetworkInfo": {
+            "EnaSupport": "unsupported",
+            "Ipv4AddressesPerInterface": 15,
+            "Ipv6AddressesPerInterface": 15,
+            "Ipv6Supported": true,
+            "MaximumNetworkInterfaces": 4,
+            "NetworkPerformance": "High"
+        },
+        "PlacementGroupInfo": {
+            "SupportedStrategies": [
+                "cluster",
+                "partition",
+                "spread"
+            ]
+        },
+        "ProcessorInfo": {
+            "SupportedArchitectures": [
+                "x86_64"
+            ],
+            "SustainedClockSpeedInGhz": 2.9
+        },
+        "SupportedRootDeviceTypes": [
+            "ebs"
+        ],
+        "SupportedUsageClasses": [
+            "on-demand",
+            "spot"
+        ],
+        "VCpuInfo": {
+            "DefaultCores": 2,
+            "DefaultThreadsPerCore": 2,
+            "DefaultVCpus": 4,
+            "ValidCores": [
+                1,
+                2
+            ],
+            "ValidThreadsPerCore": [
+                1,
+                2
+            ]
+        }
+    },
+    {
+        "AutoRecoverySupported": true,
+        "BareMetal": false,
+        "BurstablePerformanceSupported": false,
+        "CurrentGeneration": true,
+        "DedicatedHostsSupported": false,
+        "EbsInfo": {
+            "EbsOptimizedSupport": "default",
+            "EncryptionSupport": "supported"
+        },
+        "FpgaInfo": null,
+        "FreeTierEligible": false,
+        "GpuInfo": null,
+        "HibernationSupported": true,
+        "Hypervisor": "nitro",
+        "InferenceAcceleratorInfo": null,
+        "InstanceStorageInfo": null,
+        "InstanceStorageSupported": false,
+        "InstanceType": "c5.12xlarge",
+        "MemoryInfo": {
+            "SizeInMiB": 98304
+        },
+        "NetworkInfo": {
+            "EnaSupport": "required",
+            "Ipv4AddressesPerInterface": 30,
+            "Ipv6AddressesPerInterface": 30,
+            "Ipv6Supported": true,
+            "MaximumNetworkInterfaces": 8,
+            "NetworkPerformance": "12 Gigabit"
+        },
+        "PlacementGroupInfo": {
+            "SupportedStrategies": [
+                "cluster",
+                "partition",
+                "spread"
+            ]
+        },
+        "ProcessorInfo": {
+            "SupportedArchitectures": [
+                "x86_64"
+            ],
+            "SustainedClockSpeedInGhz": 3.6
+        },
+        "SupportedRootDeviceTypes": [
+            "ebs"
+        ],
+        "SupportedUsageClasses": [
+            "on-demand",
+            "spot"
+        ],
+        "VCpuInfo": {
+            "DefaultCores": 24,
+            "DefaultThreadsPerCore": 2,
+            "DefaultVCpus": 48,
+            "ValidCores": [
+                2,
+                4,
+                6,
+                8,
+                10,
+                12,
+                14,
+                16,
+                18,
+                20,
+                22,
+                24
+            ],
+            "ValidThreadsPerCore": [
+                1,
+                2
+            ]
+        }
+    },
+    {
+        "AutoRecoverySupported": true,
+        "BareMetal": false,
+        "BurstablePerformanceSupported": false,
+        "CurrentGeneration": true,
+        "DedicatedHostsSupported": true,
+        "EbsInfo": {
+            "EbsOptimizedSupport": "default",
+            "EncryptionSupport": "supported"
+        },
+        "FpgaInfo": null,
+        "FreeTierEligible": false,
+        "GpuInfo": null,
+        "HibernationSupported": true,
+        "Hypervisor": "nitro",
+        "InferenceAcceleratorInfo": null,
+        "InstanceStorageInfo": null,
+        "InstanceStorageSupported": false,
+        "InstanceType": "c5.18xlarge",
+        "MemoryInfo": {
+            "SizeInMiB": 147456
+        },
+        "NetworkInfo": {
+            "EnaSupport": "required",
+            "Ipv4AddressesPerInterface": 50,
+            "Ipv6AddressesPerInterface": 50,
+            "Ipv6Supported": true,
+            "MaximumNetworkInterfaces": 15,
+            "NetworkPerformance": "25 Gigabit"
+        },
+        "PlacementGroupInfo": {
+            "SupportedStrategies": [
+                "cluster",
+                "partition",
+                "spread"
+            ]
+        },
+        "ProcessorInfo": {
+            "SupportedArchitectures": [
+                "x86_64"
+            ],
+            "SustainedClockSpeedInGhz": 3.4
+        },
+        "SupportedRootDeviceTypes": [
+            "ebs"
+        ],
+        "SupportedUsageClasses": [
+            "on-demand",
+            "spot"
+        ],
+        "VCpuInfo": {
+            "DefaultCores": 36,
+            "DefaultThreadsPerCore": 2,
+            "DefaultVCpus": 72,
+            "ValidCores": [
+                4,
+                6,
+                8,
+                10,
+                12,
+                14,
+                16,
+                18,
+                20,
+                22,
+                24,
+                26,
+                28,
+                30,
+                32,
+                34,
+                36
+            ],
+            "ValidThreadsPerCore": [
+                1,
+                2
+            ]
+        }
+    },
+    {
+        "AutoRecoverySupported": true,
+        "BareMetal": false,
+        "BurstablePerformanceSupported": false,
+        "CurrentGeneration": true,
+        "DedicatedHostsSupported": false,
+        "EbsInfo": {
+            "EbsOptimizedSupport": "default",
+            "EncryptionSupport": "supported"
+        },
+        "FpgaInfo": null,
+        "FreeTierEligible": false,
+        "GpuInfo": null,
+        "HibernationSupported": false,
+        "Hypervisor": "nitro",
+        "InferenceAcceleratorInfo": null,
+        "InstanceStorageInfo": null,
+        "InstanceStorageSupported": false,
+        "InstanceType": "c5.24xlarge",
+        "MemoryInfo": {
+            "SizeInMiB": 196608
+        },
+        "NetworkInfo": {
+            "EnaSupport": "required",
+            "Ipv4AddressesPerInterface": 50,
+            "Ipv6AddressesPerInterface": 50,
+            "Ipv6Supported": true,
+            "MaximumNetworkInterfaces": 15,
+            "NetworkPerformance": "25 Gigabit"
+        },
+        "PlacementGroupInfo": {
+            "SupportedStrategies": [
+                "cluster",
+                "partition",
+                "spread"
+            ]
+        },
+        "ProcessorInfo": {
+            "SupportedArchitectures": [
+                "x86_64"
+            ],
+            "SustainedClockSpeedInGhz": 3.6
+        },
+        "SupportedRootDeviceTypes": [
+            "ebs"
+        ],
+        "SupportedUsageClasses": [
+            "on-demand",
+            "spot"
+        ],
+        "VCpuInfo": {
+            "DefaultCores": 48,
+            "DefaultThreadsPerCore": 2,
+            "DefaultVCpus": 96,
+            "ValidCores": [
+                2,
+                4,
+                6,
+                8,
+                10,
+                12,
+                14,
+                16,
+                18,
+                20,
+                22,
+                24,
+                26,
+                28,
+                30,
+                32,
+                34,
+                36,
+                38,
+                40,
+                42,
+                44,
+                46,
+                48
+            ],
+            "ValidThreadsPerCore": [
+                1,
+                2
+            ]
+        }
+    },
+    {
+        "AutoRecoverySupported": true,
+        "BareMetal": false,
+        "BurstablePerformanceSupported": false,
+        "CurrentGeneration": true,
+        "DedicatedHostsSupported": true,
+        "EbsInfo": {
+            "EbsOptimizedSupport": "default",
+            "EncryptionSupport": "supported"
+        },
+        "FpgaInfo": null,
+        "FreeTierEligible": false,
+        "GpuInfo": null,
+        "HibernationSupported": true,
+        "Hypervisor": "nitro",
+        "InferenceAcceleratorInfo": null,
+        "InstanceStorageInfo": null,
+        "InstanceStorageSupported": false,
+        "InstanceType": "c5.2xlarge",
+        "MemoryInfo": {
+            "SizeInMiB": 16384
+        },
+        "NetworkInfo": {
+            "EnaSupport": "required",
+            "Ipv4AddressesPerInterface": 15,
+            "Ipv6AddressesPerInterface": 15,
+            "Ipv6Supported": true,
+            "MaximumNetworkInterfaces": 4,
+            "NetworkPerformance": "Up to 10 Gigabit"
+        },
+        "PlacementGroupInfo": {
+            "SupportedStrategies": [
+                "cluster",
+                "partition",
+                "spread"
+            ]
+        },
+        "ProcessorInfo": {
+            "SupportedArchitectures": [
+                "x86_64"
+            ],
+            "SustainedClockSpeedInGhz": 3.4
+        },
+        "SupportedRootDeviceTypes": [
+            "ebs"
+        ],
+        "SupportedUsageClasses": [
+            "on-demand",
+            "spot"
+        ],
+        "VCpuInfo": {
+            "DefaultCores": 4,
+            "DefaultThreadsPerCore": 2,
+            "DefaultVCpus": 8,
+            "ValidCores": [
+                2,
+                4
+            ],
+            "ValidThreadsPerCore": [
+                1,
+                2
+            ]
+        }
+    },
+    {
+        "AutoRecoverySupported": true,
+        "BareMetal": false,
+        "BurstablePerformanceSupported": false,
+        "CurrentGeneration": true,
+        "DedicatedHostsSupported": true,
+        "EbsInfo": {
+            "EbsOptimizedSupport": "default",
+            "EncryptionSupport": "supported"
+        },
+        "FpgaInfo": null,
+        "FreeTierEligible": false,
+        "GpuInfo": null,
+        "HibernationSupported": true,
+        "Hypervisor": "nitro",
+        "InferenceAcceleratorInfo": null,
+        "InstanceStorageInfo": null,
+        "InstanceStorageSupported": false,
+        "InstanceType": "c5.4xlarge",
+        "MemoryInfo": {
+            "SizeInMiB": 32768
+        },
+        "NetworkInfo": {
+            "EnaSupport": "required",
+            "Ipv4AddressesPerInterface": 30,
+            "Ipv6AddressesPerInterface": 30,
+            "Ipv6Supported": true,
+            "MaximumNetworkInterfaces": 8,
+            "NetworkPerformance": "Up to 10 Gigabit"
+        },
+        "PlacementGroupInfo": {
+            "SupportedStrategies": [
+                "cluster",
+                "partition",
+                "spread"
+            ]
+        },
+        "ProcessorInfo": {
+            "SupportedArchitectures": [
+                "x86_64"
+            ],
+            "SustainedClockSpeedInGhz": 3.4
+        },
+        "SupportedRootDeviceTypes": [
+            "ebs"
+        ],
+        "SupportedUsageClasses": [
+            "on-demand",
+            "spot"
+        ],
+        "VCpuInfo": {
+            "DefaultCores": 8,
+            "DefaultThreadsPerCore": 2,
+            "DefaultVCpus": 16,
+            "ValidCores": [
+                2,
+                4,
+                6,
+                8
+            ],
+            "ValidThreadsPerCore": [
+                1,
+                2
+            ]
+        }
+    },
+    {
+        "AutoRecoverySupported": true,
+        "BareMetal": false,
+        "BurstablePerformanceSupported": false,
+        "CurrentGeneration": true,
+        "DedicatedHostsSupported": true,
+        "EbsInfo": {
+            "EbsOptimizedSupport": "default",
+            "EncryptionSupport": "supported"
+        },
+        "FpgaInfo": null,
+        "FreeTierEligible": false,
+        "GpuInfo": null,
+        "HibernationSupported": true,
+        "Hypervisor": "nitro",
+        "InferenceAcceleratorInfo": null,
+        "InstanceStorageInfo": null,
+        "InstanceStorageSupported": false,
+        "InstanceType": "c5.9xlarge",
+        "MemoryInfo": {
+            "SizeInMiB": 73728
+        },
+        "NetworkInfo": {
+            "EnaSupport": "required",
+            "Ipv4AddressesPerInterface": 30,
+            "Ipv6AddressesPerInterface": 30,
+            "Ipv6Supported": true,
+            "MaximumNetworkInterfaces": 8,
+            "NetworkPerformance": "10 Gigabit"
+        },
+        "PlacementGroupInfo": {
+            "SupportedStrategies": [
+                "cluster",
+                "partition",
+                "spread"
+            ]
+        },
+        "ProcessorInfo": {
+            "SupportedArchitectures": [
+                "x86_64"
+            ],
+            "SustainedClockSpeedInGhz": 3.4
+        },
+        "SupportedRootDeviceTypes": [
+            "ebs"
+        ],
+        "SupportedUsageClasses": [
+            "on-demand",
+            "spot"
+        ],
+        "VCpuInfo": {
+            "DefaultCores": 18,
+            "DefaultThreadsPerCore": 2,
+            "DefaultVCpus": 36,
+            "ValidCores": [
+                2,
+                4,
+                6,
+                8,
+                10,
+                12,
+                14,
+                16,
+                18
+            ],
+            "ValidThreadsPerCore": [
+                1,
+                2
+            ]
+        }
+    },
+    {
+        "AutoRecoverySupported": true,
+        "BareMetal": false,
+        "BurstablePerformanceSupported": false,
+        "CurrentGeneration": true,
+        "DedicatedHostsSupported": true,
+        "EbsInfo": {
+            "EbsOptimizedSupport": "default",
+            "EncryptionSupport": "supported"
+        },
+        "FpgaInfo": null,
+        "FreeTierEligible": false,
+        "GpuInfo": null,
+        "HibernationSupported": true,
+        "Hypervisor": "nitro",
+        "InferenceAcceleratorInfo": null,
+        "InstanceStorageInfo": null,
+        "InstanceStorageSupported": false,
+        "InstanceType": "c5.large",
+        "MemoryInfo": {
+            "SizeInMiB": 4096
+        },
+        "NetworkInfo": {
+            "EnaSupport": "required",
+            "Ipv4AddressesPerInterface": 10,
+            "Ipv6AddressesPerInterface": 10,
+            "Ipv6Supported": true,
+            "MaximumNetworkInterfaces": 3,
+            "NetworkPerformance": "Up to 10 Gigabit"
+        },
+        "PlacementGroupInfo": {
+            "SupportedStrategies": [
+                "cluster",
+                "partition",
+                "spread"
+            ]
+        },
+        "ProcessorInfo": {
+            "SupportedArchitectures": [
+                "x86_64"
+            ],
+            "SustainedClockSpeedInGhz": 3.4
+        },
+        "SupportedRootDeviceTypes": [
+            "ebs"
+        ],
+        "SupportedUsageClasses": [
+            "on-demand",
+            "spot"
+        ],
+        "VCpuInfo": {
+            "DefaultCores": 1,
+            "DefaultThreadsPerCore": 2,
+            "DefaultVCpus": 2,
+            "ValidCores": [
+                1
+            ],
+            "ValidThreadsPerCore": [
+                1,
+                2
+            ]
+        }
+    }
+]
+}

--- a/test/static/DescribeInstanceTypesPages/g2_2xlarge.json
+++ b/test/static/DescribeInstanceTypesPages/g2_2xlarge.json
@@ -1,0 +1,91 @@
+{
+    "InstanceTypes": [
+        {
+            "AutoRecoverySupported": false,
+            "BareMetal": false,
+            "BurstablePerformanceSupported": false,
+            "CurrentGeneration": false,
+            "DedicatedHostsSupported": true,
+            "EbsInfo": {
+                "EbsOptimizedSupport": "supported",
+                "EncryptionSupport": "supported"
+            },
+            "FpgaInfo": null,
+            "FreeTierEligible": false,
+            "GpuInfo": {
+                "Gpus": [
+                    {
+                        "Count": 1,
+                        "Manufacturer": "NVIDIA",
+                        "MemoryInfo": {
+                            "SizeInMiB": 4096
+                        },
+                        "Name": "K520"
+                    }
+                ],
+                "TotalGpuMemoryInMiB": 4096
+            },
+            "HibernationSupported": false,
+            "Hypervisor": "xen",
+            "InferenceAcceleratorInfo": null,
+            "InstanceStorageInfo": {
+                "Disks": [
+                    {
+                        "Count": 1,
+                        "SizeInGB": 60,
+                        "Type": "ssd"
+                    }
+                ],
+                "TotalSizeInGB": 60
+            },
+            "InstanceStorageSupported": true,
+            "InstanceType": "g2.2xlarge",
+            "MemoryInfo": {
+                "SizeInMiB": 15360
+            },
+            "NetworkInfo": {
+                "EnaSupport": "unsupported",
+                "Ipv4AddressesPerInterface": 15,
+                "Ipv6AddressesPerInterface": 0,
+                "Ipv6Supported": false,
+                "MaximumNetworkInterfaces": 4,
+                "NetworkPerformance": "Moderate"
+            },
+            "PlacementGroupInfo": {
+                "SupportedStrategies": [
+                    "cluster",
+                    "partition",
+                    "spread"
+                ]
+            },
+            "ProcessorInfo": {
+                "SupportedArchitectures": [
+                    "x86_64"
+                ],
+                "SustainedClockSpeedInGhz": 2.6
+            },
+            "SupportedRootDeviceTypes": [
+                "ebs",
+                "instance-store"
+            ],
+            "SupportedUsageClasses": [
+                "on-demand"
+            ],
+            "VCpuInfo": {
+                "DefaultCores": 4,
+                "DefaultThreadsPerCore": 2,
+                "DefaultVCpus": 8,
+                "ValidCores": [
+                    1,
+                    2,
+                    3,
+                    4
+                ],
+                "ValidThreadsPerCore": [
+                    1,
+                    2
+                ]
+            }
+        }
+    ]
+}

--- a/test/static/DescribeInstanceTypesPages/m4_xlarge.json
+++ b/test/static/DescribeInstanceTypesPages/m4_xlarge.json
@@ -1,0 +1,64 @@
+{
+    "InstanceTypes": [
+        {
+            "FreeTierEligible": false,
+            "InstanceStorageSupported": false,
+            "Hypervisor": "xen",
+            "PlacementGroupInfo": {
+                "SupportedStrategies": [
+                    "cluster",
+                    "partition",
+                    "spread"
+                ]
+            },
+            "SupportedUsageClasses": [
+                "on-demand",
+                "spot"
+            ],
+            "MemoryInfo": {
+                "SizeInMiB": 16384
+            },
+            "CurrentGeneration": true,
+            "DedicatedHostsSupported": true,
+            "VCpuInfo": {
+                "ValidThreadsPerCore": [
+                    1,
+                    2
+                ],
+                "DefaultCores": 2,
+                "DefaultVCpus": 4,
+                "ValidCores": [
+                    1,
+                    2
+                ],
+                "DefaultThreadsPerCore": 2
+            },
+            "ProcessorInfo": {
+                "SupportedArchitectures": [
+                    "x86_64"
+                ],
+                "SustainedClockSpeedInGhz": 2.4
+            },
+            "BareMetal": false,
+            "AutoRecoverySupported": true,
+            "NetworkInfo": {
+                "NetworkPerformance": "High",
+                "MaximumNetworkInterfaces": 4,
+                "Ipv6Supported": true,
+                "Ipv6AddressesPerInterface": 15,
+                "EnaSupport": "unsupported",
+                "Ipv4AddressesPerInterface": 15
+            },
+            "SupportedRootDeviceTypes": [
+                "ebs"
+            ],
+            "EbsInfo": {
+                "EbsOptimizedSupport": "default",
+                "EncryptionSupport": "supported"
+            },
+            "HibernationSupported": true,
+            "BurstablePerformanceSupported": false,
+            "InstanceType": "m4.xlarge"
+        }
+    ]
+}

--- a/test/static/DescribeInstanceTypesPages/t3_micro.json
+++ b/test/static/DescribeInstanceTypesPages/t3_micro.json
@@ -1,0 +1,62 @@
+{
+    "InstanceTypes": [
+        {
+            "FreeTierEligible": false,
+            "InstanceStorageSupported": false,
+            "Hypervisor": "nitro",
+            "PlacementGroupInfo": {
+                "SupportedStrategies": [
+                    "partition",
+                    "spread"
+                ]
+            },
+            "SupportedUsageClasses": [
+                "on-demand",
+                "spot"
+            ],
+            "MemoryInfo": {
+                "SizeInMiB": 1024
+            },
+            "CurrentGeneration": true,
+            "DedicatedHostsSupported": true,
+            "VCpuInfo": {
+                "ValidThreadsPerCore": [
+                    1,
+                    2
+                ],
+                "DefaultCores": 1,
+                "DefaultVCpus": 2,
+                "ValidCores": [
+                    1
+                ],
+                "DefaultThreadsPerCore": 2
+            },
+            "ProcessorInfo": {
+                "SupportedArchitectures": [
+                    "x86_64"
+                ],
+                "SustainedClockSpeedInGhz": 2.5
+            },
+            "BareMetal": false,
+            "AutoRecoverySupported": true,
+            "NetworkInfo": {
+                "NetworkPerformance": "Up to 5 Gigabit",
+                "MaximumNetworkInterfaces": 2,
+                "Ipv6Supported": true,
+                "Ipv6AddressesPerInterface": 2,
+                "EnaSupport": "required",
+                "Ipv4AddressesPerInterface": 2
+            },
+            "SupportedRootDeviceTypes": [
+                "ebs"
+            ],
+            "EbsInfo": {
+                "EbsOptimizedSupport": "default",
+                "EncryptionSupport": "supported"
+            },
+            "HibernationSupported": false,
+            "BurstablePerformanceSupported": true,
+            "InstanceType": "t3.micro"
+        }
+    ]
+}

--- a/test/static/DescribeInstanceTypesPages/t3_micro_and_p3_16xl.json
+++ b/test/static/DescribeInstanceTypesPages/t3_micro_and_p3_16xl.json
@@ -1,0 +1,149 @@
+{
+    "InstanceTypes": [
+        {
+            "FreeTierEligible": false,
+            "InstanceStorageSupported": false,
+            "Hypervisor": "nitro",
+            "PlacementGroupInfo": {
+                "SupportedStrategies": [
+                    "partition",
+                    "spread"
+                ]
+            },
+            "SupportedUsageClasses": [
+                "on-demand",
+                "spot"
+            ],
+            "MemoryInfo": {
+                "SizeInMiB": 1024
+            },
+            "CurrentGeneration": true,
+            "DedicatedHostsSupported": true,
+            "VCpuInfo": {
+                "ValidThreadsPerCore": [
+                    1,
+                    2
+                ],
+                "DefaultCores": 1,
+                "DefaultVCpus": 2,
+                "ValidCores": [
+                    1
+                ],
+                "DefaultThreadsPerCore": 2
+            },
+            "ProcessorInfo": {
+                "SupportedArchitectures": [
+                    "x86_64"
+                ],
+                "SustainedClockSpeedInGhz": 2.5
+            },
+            "BareMetal": false,
+            "AutoRecoverySupported": true,
+            "NetworkInfo": {
+                "NetworkPerformance": "Up to 5 Gigabit",
+                "MaximumNetworkInterfaces": 2,
+                "Ipv6Supported": true,
+                "Ipv6AddressesPerInterface": 2,
+                "EnaSupport": "required",
+                "Ipv4AddressesPerInterface": 2
+            },
+            "SupportedRootDeviceTypes": [
+                "ebs"
+            ],
+            "EbsInfo": {
+                "EbsOptimizedSupport": "default",
+                "EncryptionSupport": "supported"
+            },
+            "HibernationSupported": false,
+            "BurstablePerformanceSupported": true,
+            "InstanceType": "t3.micro"
+        },
+        {
+            "FreeTierEligible": false,
+            "InstanceStorageSupported": false,
+            "Hypervisor": "xen",
+            "PlacementGroupInfo": {
+                "SupportedStrategies": [
+                    "cluster",
+                    "partition",
+                    "spread"
+                ]
+            },
+            "SupportedUsageClasses": [
+                "on-demand",
+                "spot"
+            ],
+            "MemoryInfo": {
+                "SizeInMiB": 499712
+            },
+            "CurrentGeneration": true,
+            "GpuInfo": {
+                "Gpus": [
+                    {
+                        "Count": 8,
+                        "MemoryInfo": {
+                            "SizeInMiB": 16384
+                        },
+                        "Name": "V100",
+                        "Manufacturer": "NVIDIA"
+                    }
+                ],
+                "TotalGpuMemoryInMiB": 131072
+            },
+            "VCpuInfo": {
+                "ValidThreadsPerCore": [
+                    1,
+                    2
+                ],
+                "DefaultCores": 32,
+                "DefaultVCpus": 64,
+                "ValidCores": [
+                    2,
+                    4,
+                    6,
+                    8,
+                    10,
+                    12,
+                    14,
+                    16,
+                    18,
+                    20,
+                    22,
+                    24,
+                    26,
+                    28,
+                    30,
+                    32
+                ],
+                "DefaultThreadsPerCore": 2
+            },
+            "ProcessorInfo": {
+                "SupportedArchitectures": [
+                    "x86_64"
+                ],
+                "SustainedClockSpeedInGhz": 2.7
+            },
+            "BareMetal": false,
+            "AutoRecoverySupported": true,
+            "NetworkInfo": {
+                "NetworkPerformance": "25 Gigabit",
+                "MaximumNetworkInterfaces": 8,
+                "Ipv6Supported": true,
+                "Ipv6AddressesPerInterface": 30,
+                "EnaSupport": "supported",
+                "Ipv4AddressesPerInterface": 30
+            },
+            "SupportedRootDeviceTypes": [
+                "ebs"
+            ],
+            "EbsInfo": {
+                "EbsOptimizedSupport": "default",
+                "EncryptionSupport": "supported"
+            },
+            "HibernationSupported": false,
+            "DedicatedHostsSupported": true,
+            "BurstablePerformanceSupported": false,
+            "InstanceType": "p3.16xlarge"
+        }
+    ]
+}


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
 - Add --base-instance-type as the first aggregate filter
     - Returns similar instance-types based on the instance type passed in to construct flexible fleets if you are already using an instance type. 


Example: 

```
$ ec2-instance-selector --base-instance-type t3.large
m1.large
m3.large
m4.large
m5.large
m5a.large
m5ad.large
m5d.large
m5dn.large
m5n.large
t2.large
t3.large
t3a.large
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
