### PR TITLE
allow-list and deny-list implemented

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,12 +134,14 @@ ec2-instance-selector --vcpus 4 --region us-east-2 --availability-zones us-east-
 ec2-instance-selector --memory-min 4096 --memory-max 8192 --vcpus-min 4 --vcpus-max 8 --region us-east-2
 
 Filter Flags:
+      --allow-list string                 List of allowed instance types to select from w/ regex syntax (Example: m[3-5]\.*)
       --availability-zone string          [DEPRECATED] use --availability-zones instead
   -z, --availability-zones strings        Availability zones or zone ids to check EC2 capacity offered in specific AZs
       --baremetal                         Bare Metal instance types (.metal instances)
   -b, --burst-support                     Burstable instance types
   -a, --cpu-architecture string           CPU architecture [x86_64, i386, or arm64]
       --current-generation                Current generation instance types (explicitly set this to false to not return current generation instance types)
+      --deny-list string                  List of instance types which should be excluded w/ regex syntax (Example: m[1-2]\.*)
   -e, --ena-support                       Instance types where ENA is supported or required
   -f, --fpga-support                      FPGA instance types
       --gpu-memory-total int              Number of GPUs' total memory in MiB (Example: 4096) (sets --gpu-memory-total-min and -max to the same value)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -67,6 +67,8 @@ const (
 	currentGeneration      = "current-generation"
 	networkInterfaces      = "network-interfaces"
 	networkPerformance     = "network-performance"
+	allowList              = "allow-list"
+	denyList               = "deny-list"
 )
 
 // Aggregate Filter Flags
@@ -133,6 +135,8 @@ Full docs can be found at github.com/aws/amazon-` + binName
 	cli.BoolFlag(currentGeneration, nil, nil, "Current generation instance types (explicitly set this to false to not return current generation instance types)")
 	cli.IntMinMaxRangeFlags(networkInterfaces, nil, nil, "Number of network interfaces (ENIs) that can be attached to the instance")
 	cli.IntMinMaxRangeFlags(networkPerformance, nil, nil, "Bandwidth in Gib/s of network performance (Example: 100)")
+	cli.RegexFlag(allowList, nil, nil, "List of allowed instance types to select from w/ regex syntax (Example: m[3-5]\\.*)")
+	cli.RegexFlag(denyList, nil, nil, "List of instance types which should be excluded w/ regex syntax (Example: m[1-2]\\.*)")
 
 	// Suite Flags - higher level aggregate filters that return opinionated result
 
@@ -204,6 +208,8 @@ Full docs can be found at github.com/aws/amazon-` + binName
 		MaxResults:             cli.IntMe(flags[maxResults]),
 		NetworkInterfaces:      cli.IntRangeMe(flags[networkInterfaces]),
 		NetworkPerformance:     cli.IntRangeMe(flags[networkPerformance]),
+		AllowList:              cli.RegexMe(flags[allowList]),
+		DenyList:               cli.RegexMe(flags[denyList]),
 		InstanceTypeBase:       cli.StringMe(flags[instanceTypeBase]),
 	}
 

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -293,3 +293,23 @@ func TestParseAndValidateFlags(t *testing.T) {
 	_, err := cli.ParseAndValidateFlags()
 	h.Nok(t, err)
 }
+
+func TestParseAndValidateRegexFlag(t *testing.T) {
+	flagName := "test-regex-flag"
+	flagArg := fmt.Sprintf("--%s", flagName)
+
+	cli := getTestCLI()
+	cli.RegexFlag(flagName, nil, nil, "Test with validation")
+	os.Args = []string{"ec2-instance-selector", flagArg, "c4.*"}
+	flags, err := cli.ParseAndValidateFlags()
+	h.Ok(t, err)
+	h.Assert(t, len(flags) == 1, "1 flag should have been processed")
+	_, err = cli.ParseAndValidateFlags()
+	h.Ok(t, err)
+
+	cli = getTestCLI()
+	cli.RegexFlag(flagName, nil, nil, "Test with validation")
+	os.Args = []string{"ec2-instance-selector", flagArg, "(("}
+	_, err = cli.ParseAndValidateFlags()
+	h.Nok(t, err)
+}

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -150,3 +150,19 @@ func TestIntMinMaxRangeFlags(t *testing.T) {
 	h.Assert(t, len(cli.Flags) == 3, "Should contain 3 flags w/ no shorthand")
 	h.Assert(t, ok, "Should contain %s flag w/ no shorthand", flagName)
 }
+
+func TestRegexFlag(t *testing.T) {
+	cli := getTestCLI()
+	for _, flagFn := range []func(string, *string, *string, string){cli.RegexFlag} {
+		flagName := "test-regex"
+		flagFn(flagName, cli.StringMe("t"), nil, "Test Regex")
+		_, ok := cli.Flags[flagName]
+		h.Assert(t, len(cli.Flags) == 1, "Should contain 1 flag")
+		h.Assert(t, ok, "Should contain %s flag", flagName)
+
+		cli = getTestCLI()
+		flagFn(flagName, nil, nil, "Test Regex")
+		h.Assert(t, len(cli.Flags) == 1, "Should contain 1 flag w/ no shorthand")
+		h.Assert(t, ok, "Should contain %s flag w/ no shorthand", flagName)
+	}
+}

--- a/pkg/cli/types.go
+++ b/pkg/cli/types.go
@@ -16,6 +16,7 @@ package cli
 
 import (
 	"log"
+	"regexp"
 
 	"github.com/aws/amazon-ec2-instance-selector/pkg/selector"
 	"github.com/spf13/cobra"
@@ -163,6 +164,23 @@ func (*CommandLineInterface) StringSliceMe(i interface{}) *[]string {
 		return &v
 	default:
 		log.Printf("%s cannot be converted to a string list", i)
+		return nil
+	}
+}
+
+// RegexMe takes an interface and returns a pointer to a regex
+// If the underlying interface kind is not regexp.Regexp or *regexp.Regexp then nil is returned
+func (*CommandLineInterface) RegexMe(i interface{}) *regexp.Regexp {
+	if i == nil {
+		return nil
+	}
+	switch v := i.(type) {
+	case *regexp.Regexp:
+		return v
+	case regexp.Regexp:
+		return &v
+	default:
+		log.Printf("%s cannot be converted to a regexp", i)
 		return nil
 	}
 }

--- a/pkg/cli/types_test.go
+++ b/pkg/cli/types_test.go
@@ -15,6 +15,7 @@ package cli_test
 
 import (
 	"reflect"
+	"regexp"
 	"testing"
 
 	"github.com/aws/amazon-ec2-instance-selector/pkg/selector"
@@ -103,5 +104,19 @@ func TestIntRangeMe(t *testing.T) {
 	val = cli.IntRangeMe(true)
 	h.Assert(t, val == nil, "Should return nil from other data type passed in")
 	val = cli.IntRangeMe(nil)
+	h.Assert(t, val == nil, "Should return nil if nil is passed in")
+}
+
+func TestRegexMe(t *testing.T) {
+	cli := getTestCLI()
+	regexVal, err := regexp.Compile("c4.*")
+	h.Ok(t, err)
+	val := cli.RegexMe(*regexVal)
+	h.Assert(t, val.String() == regexVal.String(), "Should return %s from passed in regex value", regexVal)
+	val = cli.RegexMe(regexVal)
+	h.Assert(t, val.String() == regexVal.String(), "Should return %s from passed in regex pointer", regexVal)
+	val = cli.RegexMe(true)
+	h.Assert(t, val == nil, "Should return nil from other data type passed in")
+	val = cli.RegexMe(nil)
 	h.Assert(t, val == nil, "Should return nil if nil is passed in")
 }

--- a/pkg/selector/selector_test.go
+++ b/pkg/selector/selector_test.go
@@ -531,7 +531,7 @@ func TestFilter_DenyList(t *testing.T) {
 	}
 	results, err := itf.Filter(filters)
 	h.Ok(t, err)
-	h.Assert(t, len(results) == 24, "Allow List Regex: 'c4.large' should return 24 instance type matching regex but returned %d", len(results))
+	h.Assert(t, len(results) == 24, "Deny List Regex: 'c4.large' should return 24 instance type matching regex but returned %d", len(results))
 }
 
 func TestFilter_AllowAndDenyList(t *testing.T) {
@@ -552,5 +552,5 @@ func TestFilter_AllowAndDenyList(t *testing.T) {
 	}
 	results, err := itf.Filter(filters)
 	h.Ok(t, err)
-	h.Assert(t, len(results) == 4, "Allow List Regex: 'c4.large' should return 4 instance types matching the regex but returned %d", len(results))
+	h.Assert(t, len(results) == 4, "Allow/Deny List Regex: 'c4.large' should return 4 instance types matching the regex but returned %d", len(results))
 }

--- a/pkg/selector/selector_test.go
+++ b/pkg/selector/selector_test.go
@@ -513,7 +513,7 @@ func TestFilter_AllowList(t *testing.T) {
 	}
 	results, err := itf.Filter(filters)
 	h.Ok(t, err)
-	h.Assert(t, len(results) == 1, "c4.large should return 1 instance type matching regex")
+	h.Assert(t, len(results) == 1, "Allow List Regex: 'c4.large' should return 1 instance type")
 }
 
 func TestFilter_DenyList(t *testing.T) {
@@ -531,7 +531,7 @@ func TestFilter_DenyList(t *testing.T) {
 	}
 	results, err := itf.Filter(filters)
 	h.Ok(t, err)
-	h.Assert(t, len(results) == 24, "c4.large should return 24 instance type matching regex but returned %d", len(results))
+	h.Assert(t, len(results) == 24, "Allow List Regex: 'c4.large' should return 24 instance type matching regex but returned %d", len(results))
 }
 
 func TestFilter_AllowAndDenyList(t *testing.T) {
@@ -552,5 +552,5 @@ func TestFilter_AllowAndDenyList(t *testing.T) {
 	}
 	results, err := itf.Filter(filters)
 	h.Ok(t, err)
-	h.Assert(t, len(results) == 4, "c4.large should return 4 instance type matching regex but returned %d", len(results))
+	h.Assert(t, len(results) == 4, "Allow List Regex: 'c4.large' should return 4 instance types matching the regex but returned %d", len(results))
 }

--- a/pkg/selector/types.go
+++ b/pkg/selector/types.go
@@ -14,6 +14,8 @@
 package selector
 
 import (
+	"regexp"
+
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 )
@@ -132,6 +134,12 @@ type Filters struct {
 
 	// VcpusToMemoryRatio is a ratio of vcpus to memory expressed as a floating point
 	VCpusToMemoryRatio *float64
+
+	// AllowList is a regex of allowed instance types
+	AllowList *regexp.Regexp
+
+	// DenyList is a regex of excluded instance types
+	DenyList *regexp.Regexp
 
 	// InstanceTypeBase is a base instance type which is used to retrieve similarly spec'd instance types
 	InstanceTypeBase *string


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This PR implements allow-list and deny-list functionality for filtering instance-types out or only allowing certain instance types to be returned. The CLI accepts a string regex and the selector pkg lib accept a regexp.Regexp type for AllowList and DenyList. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
