### PR TITLE
AWS_PROFILE Env Var Support

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -276,10 +276,6 @@ func getRegionAndProfileAWSSession(regionName *string, profileName *string) (*se
 		sessOpts.Config.Region = regionName
 	}
 
-	if awsProfileName, ok := os.LookupEnv(awsProfileEnvVar); profileName == nil && ok && awsProfileName != "" {
-		profileName = &awsProfileName
-	}
-
 	if profileName != nil {
 		sessOpts.Profile = *profileName
 		if sessOpts.Config.Region == nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -32,6 +32,7 @@ import (
 const (
 	binName             = "ec2-instance-selector"
 	awsRegionEnvVar     = "AWS_REGION"
+	awsProfileEnvVar    = "AWS_PROFILE"
 	defaultRegionEnvVar = "AWS_DEFAULT_REGION"
 	defaultProfile      = "default"
 	awsConfigFile       = "~/.aws/config"
@@ -270,9 +271,13 @@ func getOutputFn(outputFlag *string, currentFn selector.InstanceTypesOutputFn) s
 }
 
 func getRegionAndProfileAWSSession(regionName *string, profileName *string) (*session.Session, error) {
-	sessOpts := session.Options{}
+	sessOpts := session.Options{SharedConfigState: session.SharedConfigEnable}
 	if regionName != nil {
 		sessOpts.Config.Region = regionName
+	}
+
+	if awsProfileName, ok := os.LookupEnv(awsProfileEnvVar); profileName != nil && ok && awsProfileName != "" {
+		profileName = &awsProfileName
 	}
 
 	if profileName != nil {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -32,7 +32,6 @@ import (
 const (
 	binName             = "ec2-instance-selector"
 	awsRegionEnvVar     = "AWS_REGION"
-	awsProfileEnvVar    = "AWS_PROFILE"
 	defaultRegionEnvVar = "AWS_DEFAULT_REGION"
 	defaultProfile      = "default"
 	awsConfigFile       = "~/.aws/config"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -276,7 +276,7 @@ func getRegionAndProfileAWSSession(regionName *string, profileName *string) (*se
 		sessOpts.Config.Region = regionName
 	}
 
-	if awsProfileName, ok := os.LookupEnv(awsProfileEnvVar); profileName != nil && ok && awsProfileName != "" {
+	if awsProfileName, ok := os.LookupEnv(awsProfileEnvVar); profileName == nil && ok && awsProfileName != "" {
 		profileName = &awsProfileName
 	}
 


### PR DESCRIPTION
*Issue #14  

**Description of changes:**
 * Following convention, if the command line arguments does not specify a profile, the code checks the AWS_PROFILE environment variable and if its not empty uses that instead of "default".  
 * The sdk session options is now initialised with SharedConfigEnable to support shared configurations from the (~/.aws/config) as described in https://github.com/aws/aws-sdk-go#configuring-credentials

There is currently no testing around the profile flag/env-var, I've done manual testing and verified rest of test cases work. Happy to take pointers on the testing side.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
