### PR TITLE
fix filters marshal to include regex strings

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -14,7 +14,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -220,12 +219,12 @@ Full docs can be found at github.com/aws/amazon-` + binName
 			fmt.Printf("An error occurred while transforming the aggregate filters")
 			os.Exit(1)
 		}
-		filtersJSON, err := json.MarshalIndent(filters, "", "    ")
+		filtersJSON, err := filters.MarshalIndent("", "    ")
 		if err != nil {
 			fmt.Printf("An error occurred when printing filters due to --verbose being specified: %v", err)
 			os.Exit(1)
 		}
-		transformedFiltersJSON, err := json.MarshalIndent(transformedFilters, "", "    ")
+		transformedFiltersJSON, err := transformedFilters.MarshalIndent("", "    ")
 		if err != nil {
 			fmt.Printf("An error occurred when printing aggregate filters due to --verbose being specified: %v", err)
 			os.Exit(1)

--- a/pkg/selector/types.go
+++ b/pkg/selector/types.go
@@ -14,6 +14,7 @@
 package selector
 
 import (
+	"encoding/json"
 	"regexp"
 
 	"github.com/aws/aws-sdk-go/service/ec2"
@@ -50,6 +51,28 @@ type IntRangeFilter struct {
 type filterPair struct {
 	filterValue  interface{}
 	instanceSpec interface{}
+}
+
+func getRegexpString(r *regexp.Regexp) *string {
+	if r == nil {
+		return nil
+	}
+	rStr := r.String()
+	return &rStr
+}
+
+// MarshalIndent is used to return a pretty-print json representation of a Filters struct
+func (f *Filters) MarshalIndent(prefix, indent string) ([]byte, error) {
+	type Alias Filters
+	return json.MarshalIndent(&struct {
+		AllowList *string
+		DenyList  *string
+		*Alias
+	}{
+		AllowList: getRegexpString(f.AllowList),
+		DenyList:  getRegexpString(f.DenyList),
+		Alias:     (*Alias)(f),
+	}, prefix, indent)
 }
 
 // Filters is used to group instance type resource attributes for filtering

--- a/pkg/selector/types_test.go
+++ b/pkg/selector/types_test.go
@@ -1,0 +1,58 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package selector_test
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/aws/amazon-ec2-instance-selector/pkg/selector"
+	h "github.com/aws/amazon-ec2-instance-selector/pkg/test"
+)
+
+// Tests
+
+func TestMarshalIndent(t *testing.T) {
+	cpuArch := "x86_64"
+	allowRegex := "^abc$"
+	denyRegex := "^zyx$"
+
+	filters := selector.Filters{
+		AllowList:       regexp.MustCompile(allowRegex),
+		DenyList:        regexp.MustCompile(denyRegex),
+		CPUArchitecture: &cpuArch,
+	}
+	out, err := filters.MarshalIndent("", "    ")
+	outStr := string(out)
+	h.Ok(t, err)
+	h.Assert(t, strings.Contains(outStr, "AllowList") && strings.Contains(outStr, allowRegex), "Does not include AllowList regex string")
+	h.Assert(t, strings.Contains(outStr, "DenyList") && strings.Contains(outStr, denyRegex), "Does not include DenyList regex string")
+
+}
+
+func TestMarshalIndent_nil(t *testing.T) {
+	denyRegex := "^zyx$"
+
+	filters := selector.Filters{
+		AllowList: nil,
+		DenyList:  regexp.MustCompile(denyRegex),
+	}
+	out, err := filters.MarshalIndent("", "    ")
+	outStr := string(out)
+	h.Ok(t, err)
+	h.Assert(t, strings.Contains(outStr, "AllowList") && strings.Contains(outStr, "null"), "Does not include AllowList null entry")
+	h.Assert(t, strings.Contains(outStr, "DenyList") && strings.Contains(outStr, denyRegex), "Does not include DenyList regex string")
+
+}


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
 allow-list and deny-list were the first two regex and more complex data types introduced to the filters struct. `encoding/json` does not properly return the string representation of `regexp.Regexp` which breaks the verbose filter output since it used `json.Marshal`. This PR implements a `MarshalIndent` on the Filters type. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
