### PR TITLE
fixed vcpus-to-memory ratio calc to use ceiling

### DIFF
--- a/pkg/selector/comparators.go
+++ b/pkg/selector/comparators.go
@@ -141,7 +141,7 @@ func supportSyntaxToBool(instanceTypeSupport *string) *bool {
 }
 
 func calculateVCpusToMemoryRatio(vcpusVal *int64, memoryVal *int64) *float64 {
-	if vcpusVal == nil || memoryVal == nil {
+	if vcpusVal == nil || *vcpusVal == 0 || memoryVal == nil {
 		return nil
 	}
 	// normalize vcpus to a mebivcpu value

--- a/pkg/selector/comparators.go
+++ b/pkg/selector/comparators.go
@@ -145,7 +145,8 @@ func calculateVCpusToMemoryRatio(vcpusVal *int64, memoryVal *int64) *float64 {
 		return nil
 	}
 	// normalize vcpus to a mebivcpu value
-	return aws.Float64(float64(*memoryVal) / float64(*vcpusVal*1024))
+	result := math.Ceil(float64(*memoryVal) / float64(*vcpusVal*1024))
+	return &result
 }
 
 // Slice helper function

--- a/pkg/selector/comparators_internal_test.go
+++ b/pkg/selector/comparators_internal_test.go
@@ -217,17 +217,17 @@ func TestCalculateVCpusToMemoryRatio(t *testing.T) {
 	vcpus := aws.Int64(4)
 	memory := aws.Int64(4096)
 	ratio := calculateVCpusToMemoryRatio(vcpus, memory)
-	h.Assert(t, *ratio == 1.00, "nil should evaluate to nil")
+	h.Assert(t, *ratio == 1.00, "ratio should equal 1:1")
 
 	vcpus = aws.Int64(2)
 	memory = aws.Int64(4096)
 	ratio = calculateVCpusToMemoryRatio(vcpus, memory)
-	h.Assert(t, *ratio == 2.00, "nil should evaluate to nil")
+	h.Assert(t, *ratio == 2.00, "ration should equal 1:2")
 
 	vcpus = aws.Int64(1)
 	memory = aws.Int64(512)
 	ratio = calculateVCpusToMemoryRatio(vcpus, memory)
-	h.Assert(t, *ratio == 0.50, "nil should evaluate to nil")
+	h.Assert(t, *ratio == 1.0, "ratio should take the ceiling which equals 1:1")
 }
 
 func TestCalculateVCpusToMemoryRatio_Nil(t *testing.T) {

--- a/pkg/selector/comparators_internal_test.go
+++ b/pkg/selector/comparators_internal_test.go
@@ -222,12 +222,17 @@ func TestCalculateVCpusToMemoryRatio(t *testing.T) {
 	vcpus = aws.Int64(2)
 	memory = aws.Int64(4096)
 	ratio = calculateVCpusToMemoryRatio(vcpus, memory)
-	h.Assert(t, *ratio == 2.00, "ration should equal 1:2")
+	h.Assert(t, *ratio == 2.00, "ratio should equal 1:2")
 
 	vcpus = aws.Int64(1)
 	memory = aws.Int64(512)
 	ratio = calculateVCpusToMemoryRatio(vcpus, memory)
 	h.Assert(t, *ratio == 1.0, "ratio should take the ceiling which equals 1:1")
+
+	vcpus = aws.Int64(0)
+	memory = aws.Int64(512)
+	ratio = calculateVCpusToMemoryRatio(vcpus, memory)
+	h.Assert(t, ratio == nil, "ratio should be nil when vcpus is 0")
 }
 
 func TestCalculateVCpusToMemoryRatio_Nil(t *testing.T) {


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
The vcpus-to-memory-ratio was computed to 2 decimal places, but this isn't lenient enough for old instance types that have odd ratios. This change uses the ceiling so that old instance types are returned for ratios that are close enough. 

This change also fixes some copy and paste errors in the test failure output. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
