### PR TITLE
lower aggregate percent lower-band to reduce variance in instance resource specs

### DIFF
--- a/pkg/selector/aggregates.go
+++ b/pkg/selector/aggregates.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	// AggregateLowPercentile is the default lower percentile for resource ranges on similar instance type comparisons
-	AggregateLowPercentile = 0.8
+	AggregateLowPercentile = 0.9
 	// AggregateHighPercentile is the default upper percentile for resource ranges on similar instance type comparisons
 	AggregateHighPercentile = 1.2
 )


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
 - lower aggregate percent lower-band to reduce variance in instance resource specs


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
