### PR TITLE
Homebrew-sync gh config backup fix

### DIFF
--- a/scripts/sync-to-aws-homebrew-tap
+++ b/scripts/sync-to-aws-homebrew-tap
@@ -96,8 +96,9 @@ function restore_gh_config() {
 
 if [[ -n $(env | grep GITHUB_TOKEN) ]] && [[ -n "${GITHUB_TOKEN}" ]]; then
   trap restore_gh_config EXIT INT TERM ERR
-  cp -f "${HOME}/.config/gh/config.yml" "${HOME}/.config/gh/config.yml.bkup"
-  cat << EOF > "${HOME}/.config/gh/config.yml"
+  mkdir -p "${HOME}/.config/gh"
+  cp -f "${GH_CLI_CONFIG_PATH}" "${GH_CLI_CONFIG_PATH}.bkup"
+  cat << EOF > "${GH_CLI_CONFIG_PATH}"
 hosts:
     github.com:
         oauth_token: ${GITHUB_TOKEN}

--- a/scripts/sync-to-aws-homebrew-tap
+++ b/scripts/sync-to-aws-homebrew-tap
@@ -97,7 +97,7 @@ function restore_gh_config() {
 if [[ -n $(env | grep GITHUB_TOKEN) ]] && [[ -n "${GITHUB_TOKEN}" ]]; then
   trap restore_gh_config EXIT INT TERM ERR
   mkdir -p "${HOME}/.config/gh"
-  cp -f "${GH_CLI_CONFIG_PATH}" "${GH_CLI_CONFIG_PATH}.bkup"
+  cp -f "${GH_CLI_CONFIG_PATH}" "${GH_CLI_CONFIG_PATH}.bkup" || :
   cat << EOF > "${GH_CLI_CONFIG_PATH}"
 hosts:
     github.com:


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
 - Turns out there's not gh config in a travis build so no backup needed! But it shouldn't fail when it can't back up a non-existent file... so here we are. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
