### PR TITLE
prevent caching on brew sync

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ jobs:
       if: type = push AND tag =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/ AND env(DOCKERHUB_USERNAME) IS present
       script: make release
       name: Release Assets
-    - stage: Deploy
+    - stage: Sync to Homebrew
       if: type = push AND tag =~ /^v\d+\.\d+(\.\d+)?(-\S*)?$/ AND env(GITHUB_USERNAME) IS present
       script: make homebrew-sync
       name: Sync to AWS homebrew-tap

--- a/scripts/sync-to-aws-homebrew-tap
+++ b/scripts/sync-to-aws-homebrew-tap
@@ -136,7 +136,7 @@ for os_arch in "${PLATFORMS[@]}"; do
     asset_file="${BINARY_BASE}-${os}-${arch}.tar.gz"
     asset_file_path="${DOWNLOAD_DIR}/${asset_file}"
 
-    curl -Lo "${asset_file_path}" "${asset_url}"
+    curl -H 'Cache-Control: no-cache' -Lo "${asset_file_path}" "${asset_url}?$(date +%s)"
 
     asset_file_size=$(du -k "${asset_file_path}" | cut -f1)
     if [[ "${asset_file_size}" -lt 100 ]]; then
@@ -184,7 +184,7 @@ if [[ "${DRY_RUN}" -eq 0 ]]; then
   cd "${SYNC_DIR}"
   gh repo fork $TAP_REPO --clone --remote
   cd "${FORK_DIR}"
-  git remote set-url origin https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/${TAP_REPO}.git
+  git remote set-url origin https://${GITHUB_USERNAME}:${GITHUB_TOKEN}@github.com/${GITHUB_USERNAME}/${TAP_NAME}.git
   DEFAULT_BRANCH=$(git rev-parse --abbrev-ref HEAD | tr -d '\n')
 
   cp "${BREW_CONFIG_DIR}/${BINARY_BASE}.json" "${FORK_DIR}/bottle-configs/${BINARY_BASE}.json"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
 - Prevent caching when downloading the github release assets by setting the no-cache header and an arbitrary query string
 - Sync to homebrew tap AFTER the release assets have been uploaded :) 
 - Fix remote origin to use fork instead of actual repo 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
