### PR TITLE
treat amd64 the same as x86_64

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Filter Flags:
   -z, --availability-zones strings        Availability zones or zone ids to check EC2 capacity offered in specific AZs
       --baremetal                         Bare Metal instance types (.metal instances)
   -b, --burst-support                     Burstable instance types
-  -a, --cpu-architecture string           CPU architecture [x86_64, i386, or arm64]
+  -a, --cpu-architecture string           CPU architecture [x86_64/amd64, i386, or arm64]
       --current-generation                Current generation instance types (explicitly set this to false to not return current generation instance types)
       --deny-list string                  List of instance types which should be excluded w/ regex syntax (Example: m[1-2]\.*)
   -e, --ena-support                       Instance types where ENA is supported or required

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -118,7 +118,7 @@ Full docs can be found at github.com/aws/amazon-` + binName
 	cli.IntMinMaxRangeFlags(vcpus, cli.StringMe("c"), nil, "Number of vcpus available to the instance type.")
 	cli.IntMinMaxRangeFlags(memory, cli.StringMe("m"), nil, "Amount of Memory available in MiB (Example: 4096)")
 	cli.RatioFlag(vcpusToMemoryRatio, nil, nil, "The ratio of vcpus to memory in MiB. (Example: 1:2)")
-	cli.StringFlag(cpuArchitecture, cli.StringMe("a"), nil, "CPU architecture [x86_64, i386, or arm64]", nil)
+	cli.StringFlag(cpuArchitecture, cli.StringMe("a"), nil, "CPU architecture [x86_64/amd64, i386, or arm64]", nil)
 	cli.IntMinMaxRangeFlags(gpus, cli.StringMe("g"), nil, "Total Number of GPUs (Example: 4)")
 	cli.IntMinMaxRangeFlags(gpuMemoryTotal, nil, nil, "Number of GPUs' total memory in MiB (Example: 4096)")
 	cli.StringFlag(placementGroupStrategy, nil, nil, "Placement group strategy: [cluster, partition, spread]", nil)

--- a/pkg/selector/selector.go
+++ b/pkg/selector/selector.go
@@ -62,6 +62,9 @@ const (
 	networkPerformance     = "networkPerformance"
 	allowList              = "allowList"
 	denyList               = "denyList"
+
+	cpuArchitectureAMD64 = "amd64"
+	cpuArchitectureX8664 = "x86_64"
 )
 
 // New creates an instance of Selector provided an aws session
@@ -147,6 +150,10 @@ func (itf Selector) rawFilter(filters Filters) ([]*ec2.InstanceTypeInfo, error) 
 		} else {
 			filters.AvailabilityZones = &[]string{*filters.AvailabilityZone}
 		}
+	}
+
+	if filters.CPUArchitecture != nil && *filters.CPUArchitecture == cpuArchitectureAMD64 {
+		*filters.CPUArchitecture = cpuArchitectureX8664
 	}
 
 	if filters.AvailabilityZones != nil {

--- a/pkg/selector/selector_test.go
+++ b/pkg/selector/selector_test.go
@@ -554,3 +554,18 @@ func TestFilter_AllowAndDenyList(t *testing.T) {
 	h.Ok(t, err)
 	h.Assert(t, len(results) == 4, "Allow/Deny List Regex: 'c4.large' should return 4 instance types matching the regex but returned %d", len(results))
 }
+
+func TestFilter_X8664_AMD64(t *testing.T) {
+	ec2Mock := setupMock(t, describeInstanceTypesPages, "t3_micro.json")
+	itf := selector.Selector{
+		EC2: ec2Mock,
+	}
+	filters := selector.Filters{
+		CPUArchitecture: aws.String("amd64"),
+	}
+	results, err := itf.Filter(filters)
+	h.Ok(t, err)
+	log.Println(results)
+	h.Assert(t, len(results) == 1, "Should only return 1 instance type with x86_64/amd64 cpu architecture")
+	h.Assert(t, results[0] == "t3.micro", "Should return t3.micro, got %s instead", results[0])
+}

--- a/pkg/selector/types.go
+++ b/pkg/selector/types.go
@@ -96,7 +96,7 @@ type Filters struct {
 	Burstable *bool
 
 	// CPUArchitecture of the EC2 instance type
-	// Possible values are: x86_64 or arm64
+	// Possible values are: x86_64/amd64 or arm64
 	CPUArchitecture *string
 
 	// CurrentGeneration returns the latest generation of instance types


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
 - The EC2 API uses x86_64 to denote AMD64 architecture, but they are effectively the equivalent. Especially in the world of k8s, amd64 is used since golang uses amd64 as a GOARCH for building.  In this PR, the selector pkg will accept x86_64 or amd64. If amd64 is passed in, it will be transformed when the rawFilters are executed to become x86_64 so that the EC2 API response matches. 




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
