### PR TITLE
Ratio filter

### DIFF
--- a/pkg/selector/comparators.go
+++ b/pkg/selector/comparators.go
@@ -55,6 +55,17 @@ func isSupportedWithRangeInt(instanceTypeValue *int, target *IntRangeFilter) boo
 	return isSupportedWithRangeInt64(instanceTypeValueInt64, target)
 }
 
+func isSupportedWithFloat64(instanceTypeValue *float64, target *float64) bool {
+	if target == nil {
+		return true
+	}
+	if instanceTypeValue == nil {
+		return false
+	}
+	// compare up to values' two decimal floor
+	return math.Floor(*instanceTypeValue*100)/100 == math.Floor(*target*100)/100
+}
+
 func isSupportedWithRangeInt64(instanceTypeValue *int64, target *IntRangeFilter) bool {
 	if target == nil {
 		return true

--- a/pkg/selector/comparators_internal_test.go
+++ b/pkg/selector/comparators_internal_test.go
@@ -191,6 +191,43 @@ func TestIsSupportedWithRangeUint64_Overflow(t *testing.T) {
 	h.Assert(t, isSupported == true, "Uint64RangeFilter should match with 0 - MAX target and source 4")
 }
 
+// float64
+
+func TestIsSupportedWithFloat64_Supported(t *testing.T) {
+	isSupported := isSupportedWithFloat64(aws.Float64(0.33), aws.Float64(0.33))
+	h.Assert(t, isSupported == true, "Float64 comparison should match exactly with 2 decimal places")
+}
+
+func TestIsSupportedWithFloat64_SupportedTruncatedDecPlacesExact(t *testing.T) {
+	isSupported := isSupportedWithFloat64(aws.Float64(0.3322), aws.Float64(0.3322))
+	h.Assert(t, isSupported == true, "Float64 comparison should match exactly with 4 decimal places")
+}
+
+func TestIsSupportedWithFloat64_SupportedTruncatedDecPlaces(t *testing.T) {
+	isSupported := isSupportedWithFloat64(aws.Float64(0.3399), aws.Float64(0.3311))
+	h.Assert(t, isSupported == true, "Float64 comparison should match when truncating to 2 decimal places")
+}
+
+func TestIsSupportedWithFloat64_Unsupported(t *testing.T) {
+	isSupported := isSupportedWithFloat64(aws.Float64(0.4), aws.Float64(0.3399))
+	h.Assert(t, isSupported == false, "Float64 comparison should NOT match")
+}
+
+func TestIsSupportedWithFloat64_SourceNil(t *testing.T) {
+	isSupported := isSupportedWithFloat64(nil, aws.Float64(0.3399))
+	h.Assert(t, isSupported == false, "Float64 comparison should NOT match with nil source")
+}
+
+func TestIsSupportedWithFloat64_TargetNil(t *testing.T) {
+	isSupported := isSupportedWithFloat64(aws.Float64(0.3399), nil)
+	h.Assert(t, isSupported == true, "Float64 comparison should match with nil target")
+}
+
+func TestIsSupportedWithFloat64_BothNil(t *testing.T) {
+	isSupported := isSupportedWithFloat64(nil, nil)
+	h.Assert(t, isSupported == true, "Float64 comparison should match with nil target and source")
+}
+
 // bools
 
 func TestSupportSyntaxToBool_Supported(t *testing.T) {

--- a/pkg/selector/outputs/outputs.go
+++ b/pkg/selector/outputs/outputs.go
@@ -201,7 +201,7 @@ func TableOutputWide(instanceTypeInfoSlice []*ec2.InstanceTypeInfo) []string {
 	headers := []interface{}{
 		"Instance Type",
 		"VCPUs",
-		"Mem (MiB)",
+		"Mem (GiB)",
 		"Hypervisor",
 		"Current Gen",
 		"Hibernation Support",
@@ -209,7 +209,7 @@ func TableOutputWide(instanceTypeInfoSlice []*ec2.InstanceTypeInfo) []string {
 		"Network Performance",
 		"ENIs",
 		"GPUs",
-		"GPU Mem (MiB)",
+		"GPU Mem (GiB)",
 		"GPU Info",
 	}
 	separators := []interface{}{}

--- a/pkg/selector/selector.go
+++ b/pkg/selector/selector.go
@@ -323,6 +323,15 @@ func (itf Selector) executeFilters(filterToInstanceSpecMapping map[string]filter
 			default:
 				return false, fmt.Errorf(invalidInstanceSpecTypeMsg)
 			}
+		case *float64:
+			switch iSpec := instanceSpec.(type) {
+			case *float64:
+				if !isSupportedWithFloat64(iSpec, filter) {
+					return false, nil
+				}
+			default:
+				return false, fmt.Errorf(invalidInstanceSpecTypeMsg)
+			}
 		default:
 			return false, fmt.Errorf("No filter handler found for %s", filterDetailsMsg)
 		}


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
 - added float64 comparisons back since they were used for vcpus-to-memory-ratio comparisons
 - fixed table wide output labels for memory and gpu memory from MiB to GiB

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
