### PR TITLE
remove az for pending major release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,6 +44,7 @@ jobs:
       name: License Test
     - stage: Test
       if: type = push AND env(GITHUB_TOKEN) IS present
+      go: "1.14.x"
       script: make e2e-test
       name: E2E Tests
     - stage: Deploy

--- a/README.md
+++ b/README.md
@@ -136,7 +136,6 @@ ec2-instance-selector --memory-min 4 --memory-max 8 --vcpus-min 4 --vcpus-max 8 
 
 Filter Flags:
       --allow-list string                 List of allowed instance types to select from w/ regex syntax (Example: m[3-5]\.*)
-      --availability-zone string          [DEPRECATED] use --availability-zones instead
   -z, --availability-zones strings        Availability zones or zone ids to check EC2 capacity offered in specific AZs
       --baremetal                         Bare Metal instance types (.metal instances)
   -b, --burst-support                     Burstable instance types

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -61,7 +61,6 @@ const (
 	fpgaSupport            = "fpga-support"
 	burstSupport           = "burst-support"
 	hypervisor             = "hypervisor"
-	availabilityZone       = "availability-zone"
 	availabilityZones      = "availability-zones"
 	currentGeneration      = "current-generation"
 	networkInterfaces      = "network-interfaces"
@@ -130,7 +129,6 @@ Full docs can be found at github.com/aws/amazon-` + binName
 	cli.BoolFlag(fpgaSupport, cli.StringMe("f"), nil, "FPGA instance types")
 	cli.BoolFlag(burstSupport, cli.StringMe("b"), nil, "Burstable instance types")
 	cli.StringFlag(hypervisor, nil, nil, "Hypervisor: [xen or nitro]", nil)
-	cli.StringFlag(availabilityZone, nil, nil, "[DEPRECATED] use --availability-zones instead", nil)
 	cli.StringSliceFlag(availabilityZones, cli.StringMe("z"), nil, "Availability zones or zone ids to check EC2 capacity offered in specific AZs")
 	cli.BoolFlag(currentGeneration, nil, nil, "Current generation instance types (explicitly set this to false to not return current generation instance types)")
 	cli.IntMinMaxRangeFlags(networkInterfaces, nil, nil, "Number of network interfaces (ENIs) that can be attached to the instance")
@@ -175,15 +173,6 @@ Full docs can be found at github.com/aws/amazon-` + binName
 		os.Exit(1)
 	}
 	flags[region] = sess.Config.Region
-
-	if flags[availabilityZone] != nil {
-		log.Printf("You are using a deprecated flag --%s which will be removed in future versions, switch to --%s to avoid issues.\n", availabilityZone, availabilityZones)
-		if flags[availabilityZones] != nil {
-			flags[availabilityZones] = append(*cli.StringSliceMe(flags[availabilityZones]), *cli.StringMe(flags[availabilityZone]))
-		} else {
-			flags[availabilityZones] = []string{*cli.StringMe(flags[availabilityZone])}
-		}
-	}
 
 	instanceSelector := selector.New(sess)
 

--- a/pkg/selector/selector.go
+++ b/pkg/selector/selector.go
@@ -143,15 +143,6 @@ func (itf Selector) rawFilter(filters Filters) ([]*ec2.InstanceTypeInfo, error) 
 	}
 	var locations []string
 
-	// Support the deprecated singular availabilityZone filter in favor of the plural
-	if filters.AvailabilityZone != nil {
-		if filters.AvailabilityZones != nil {
-			*filters.AvailabilityZones = append(*filters.AvailabilityZones, *filters.AvailabilityZone)
-		} else {
-			filters.AvailabilityZones = &[]string{*filters.AvailabilityZone}
-		}
-	}
-
 	if filters.CPUArchitecture != nil && *filters.CPUArchitecture == cpuArchitectureAMD64 {
 		*filters.CPUArchitecture = cpuArchitectureX8664
 	}

--- a/pkg/selector/selector_test.go
+++ b/pkg/selector/selector_test.go
@@ -197,8 +197,8 @@ func TestFilterVerbose_AZFilteredIn(t *testing.T) {
 		EC2: ec2Mock,
 	}
 	filters := selector.Filters{
-		VCpusRange:       &selector.IntRangeFilter{LowerBound: 2, UpperBound: 2},
-		AvailabilityZone: aws.String("us-east-2a"),
+		VCpusRange:        &selector.IntRangeFilter{LowerBound: 2, UpperBound: 2},
+		AvailabilityZones: &[]string{"us-east-2a"},
 	}
 	results, err := itf.FilterVerbose(filters)
 	h.Ok(t, err)
@@ -216,7 +216,7 @@ func TestFilterVerbose_AZFilteredOut(t *testing.T) {
 		EC2: ec2Mock,
 	}
 	filters := selector.Filters{
-		AvailabilityZone: aws.String("us-east-2a"),
+		AvailabilityZones: &[]string{"us-east-2a"},
 	}
 	results, err := itf.FilterVerbose(filters)
 	h.Ok(t, err)
@@ -229,8 +229,8 @@ func TestFilterVerboseAZ_FilteredErr(t *testing.T) {
 		EC2: ec2Mock,
 	}
 	filters := selector.Filters{
-		VCpusRange:       &selector.IntRangeFilter{LowerBound: 2, UpperBound: 2},
-		AvailabilityZone: aws.String("blah"),
+		VCpusRange:        &selector.IntRangeFilter{LowerBound: 2, UpperBound: 2},
+		AvailabilityZones: &[]string{"blah"},
 	}
 	_, err := itf.FilterVerbose(filters)
 	h.Assert(t, err != nil, "Should error since bad zone was passed in")

--- a/pkg/selector/types.go
+++ b/pkg/selector/types.go
@@ -98,12 +98,6 @@ type Filters struct {
 	// Example: us-east-1a, us-east-1b, us-east-2a, etc. OR use1-az1, use2-az2, etc.
 	AvailabilityZones *[]string
 
-	// AvailabilityZone [DEPRECATED] is the AWS Availability Zone where instances will be provisioned.
-	// Instance type capacity can vary between availability zones.
-	// Will accept zone name or id
-	// Example: us-east-1a, us-east-1b, us-east-2a, etc. OR use1-az1, use2-az2, etc.
-	AvailabilityZone *string
-
 	// BareMetal is used to only return bare metal instance type results
 	BareMetal *bool
 


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
 - The singular AZ param was deprecated previously, but since we are pending a major release to include the ByteQuantity changes, we can remove the singular AZ handling in favor of the plural --availability-zones param.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
