### PR TITLE
update go module path /v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GOPROXY ?= "https://proxy.golang.org,direct"
 MAKEFILE_PATH = $(dir $(realpath -s $(firstword $(MAKEFILE_LIST))))
 BUILD_DIR_PATH = ${MAKEFILE_PATH}/build
 SUPPORTED_PLATFORMS ?= "windows/amd64,darwin/amd64,linux/amd64,linux/arm64,linux/arm"
-SELECTOR_PKG_VERSION_VAR=github.com/aws/amazon-ec2-instance-selector/pkg/selector.versionID
+SELECTOR_PKG_VERSION_VAR=github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector.versionID
 LATEST_RELEASE_TAG=$(shell git tag | tail -1)
 PREVIOUS_RELEASE_TAG=$(shell git tag | tail -2 | head -1)
 

--- a/README.md
+++ b/README.md
@@ -207,8 +207,8 @@ package main
 import (
 	"fmt"
 
-	"github.com/aws/amazon-ec2-instance-selector/pkg/bytequantity"
-	"github.com/aws/amazon-ec2-instance-selector/pkg/selector"
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/bytequantity"
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 )

--- a/cmd/examples/example1.go
+++ b/cmd/examples/example1.go
@@ -3,8 +3,8 @@ package main
 import (
 	"fmt"
 
-	"github.com/aws/amazon-ec2-instance-selector/pkg/bytequantity"
-	"github.com/aws/amazon-ec2-instance-selector/pkg/selector"
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/bytequantity"
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 )

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -19,9 +19,9 @@ import (
 	"os"
 	"strings"
 
-	commandline "github.com/aws/amazon-ec2-instance-selector/pkg/cli"
-	"github.com/aws/amazon-ec2-instance-selector/pkg/selector"
-	"github.com/aws/amazon-ec2-instance-selector/pkg/selector/outputs"
+	commandline "github.com/aws/amazon-ec2-instance-selector/v2/pkg/cli"
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector"
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector/outputs"
 	"github.com/aws/aws-sdk-go/aws/session"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/aws/amazon-ec2-instance-selector
+module github.com/aws/amazon-ec2-instance-selector/v2
 
 go 1.14
 

--- a/pkg/bytequantity/bytequantity_test.go
+++ b/pkg/bytequantity/bytequantity_test.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/amazon-ec2-instance-selector/pkg/bytequantity"
-	h "github.com/aws/amazon-ec2-instance-selector/pkg/test"
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/bytequantity"
+	h "github.com/aws/amazon-ec2-instance-selector/v2/pkg/test"
 )
 
 func TestParseToByteQuantity(t *testing.T) {

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -20,8 +20,8 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/aws/amazon-ec2-instance-selector/pkg/bytequantity"
-	"github.com/aws/amazon-ec2-instance-selector/pkg/selector"
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/bytequantity"
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )

--- a/pkg/cli/cli_internal_test.go
+++ b/pkg/cli/cli_internal_test.go
@@ -17,7 +17,7 @@ import (
 	"os"
 	"testing"
 
-	h "github.com/aws/amazon-ec2-instance-selector/pkg/test"
+	h "github.com/aws/amazon-ec2-instance-selector/v2/pkg/test"
 	"github.com/spf13/pflag"
 )
 

--- a/pkg/cli/cli_test.go
+++ b/pkg/cli/cli_test.go
@@ -20,10 +20,10 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/aws/amazon-ec2-instance-selector/pkg/bytequantity"
-	"github.com/aws/amazon-ec2-instance-selector/pkg/cli"
-	"github.com/aws/amazon-ec2-instance-selector/pkg/selector"
-	h "github.com/aws/amazon-ec2-instance-selector/pkg/test"
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/bytequantity"
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/cli"
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector"
+	h "github.com/aws/amazon-ec2-instance-selector/v2/pkg/test"
 	"github.com/spf13/cobra"
 )
 

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/aws/amazon-ec2-instance-selector/pkg/bytequantity"
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/bytequantity"
 	"github.com/spf13/pflag"
 )
 

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -17,8 +17,8 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/aws/amazon-ec2-instance-selector/pkg/bytequantity"
-	h "github.com/aws/amazon-ec2-instance-selector/pkg/test"
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/bytequantity"
+	h "github.com/aws/amazon-ec2-instance-selector/v2/pkg/test"
 )
 
 // Tests

--- a/pkg/cli/types.go
+++ b/pkg/cli/types.go
@@ -18,8 +18,8 @@ import (
 	"log"
 	"regexp"
 
-	"github.com/aws/amazon-ec2-instance-selector/pkg/bytequantity"
-	"github.com/aws/amazon-ec2-instance-selector/pkg/selector"
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/bytequantity"
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )

--- a/pkg/cli/types_test.go
+++ b/pkg/cli/types_test.go
@@ -18,9 +18,9 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/aws/amazon-ec2-instance-selector/pkg/bytequantity"
-	"github.com/aws/amazon-ec2-instance-selector/pkg/selector"
-	h "github.com/aws/amazon-ec2-instance-selector/pkg/test"
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/bytequantity"
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector"
+	h "github.com/aws/amazon-ec2-instance-selector/v2/pkg/test"
 )
 
 // Tests

--- a/pkg/selector/aggregates.go
+++ b/pkg/selector/aggregates.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"regexp"
 
-	"github.com/aws/amazon-ec2-instance-selector/pkg/bytequantity"
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/bytequantity"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/ec2"
 )

--- a/pkg/selector/aggregates_test.go
+++ b/pkg/selector/aggregates_test.go
@@ -16,8 +16,8 @@ package selector_test
 import (
 	"testing"
 
-	"github.com/aws/amazon-ec2-instance-selector/pkg/selector"
-	h "github.com/aws/amazon-ec2-instance-selector/pkg/test"
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector"
+	h "github.com/aws/amazon-ec2-instance-selector/v2/pkg/test"
 )
 
 // Tests

--- a/pkg/selector/comparators_internal_test.go
+++ b/pkg/selector/comparators_internal_test.go
@@ -17,7 +17,7 @@ import (
 	"math"
 	"testing"
 
-	h "github.com/aws/amazon-ec2-instance-selector/pkg/test"
+	h "github.com/aws/amazon-ec2-instance-selector/v2/pkg/test"
 	"github.com/aws/aws-sdk-go/aws"
 )
 

--- a/pkg/selector/outputs/outputs_test.go
+++ b/pkg/selector/outputs/outputs_test.go
@@ -20,8 +20,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aws/amazon-ec2-instance-selector/pkg/selector/outputs"
-	h "github.com/aws/amazon-ec2-instance-selector/pkg/test"
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector/outputs"
+	h "github.com/aws/amazon-ec2-instance-selector/v2/pkg/test"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/ghodss/yaml"
 	"github.com/hashicorp/hcl"

--- a/pkg/selector/selector.go
+++ b/pkg/selector/selector.go
@@ -21,7 +21,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/aws/amazon-ec2-instance-selector/pkg/selector/outputs"
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector/outputs"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"

--- a/pkg/selector/selector_test.go
+++ b/pkg/selector/selector_test.go
@@ -22,9 +22,9 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/aws/amazon-ec2-instance-selector/pkg/bytequantity"
-	"github.com/aws/amazon-ec2-instance-selector/pkg/selector"
-	h "github.com/aws/amazon-ec2-instance-selector/pkg/test"
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/bytequantity"
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector"
+	h "github.com/aws/amazon-ec2-instance-selector/v2/pkg/test"
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/ec2"

--- a/pkg/selector/types.go
+++ b/pkg/selector/types.go
@@ -17,7 +17,7 @@ import (
 	"encoding/json"
 	"regexp"
 
-	"github.com/aws/amazon-ec2-instance-selector/pkg/bytequantity"
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/bytequantity"
 	"github.com/aws/aws-sdk-go/service/ec2"
 	"github.com/aws/aws-sdk-go/service/ec2/ec2iface"
 )

--- a/pkg/selector/types_test.go
+++ b/pkg/selector/types_test.go
@@ -18,8 +18,8 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/aws/amazon-ec2-instance-selector/pkg/selector"
-	h "github.com/aws/amazon-ec2-instance-selector/pkg/test"
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector"
+	h "github.com/aws/amazon-ec2-instance-selector/v2/pkg/test"
 )
 
 // Tests


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/golang/go/issues/35732

*Description of changes:*
 - add /v2 to go module path 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
