### PR TITLE
upgrade to go 1.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 # Build the manager binary
-FROM golang:1.14 as builder
+FROM golang:1.15 as builder
 
 ## GOLANG env
-ARG GOPROXY="https://proxy.golang.org,direct"
+ARG GOPROXY="https://proxy.golang.org|direct"
 ARG GO111MODULE="on"
 ARG CGO_ENABLED=0
 ARG GOOS=linux 

--- a/Makefile
+++ b/Makefile
@@ -22,8 +22,7 @@ repo-full-name:
 	@echo ${REPO_FULL_NAME}
 
 compile:
-	@echo ${MAKEFILE_PATH}
-	go build -a -ldflags "-X main.versionID=${VERSION} -X ${SELECTOR_PKG_VERSION_VAR}=${VERSION}" -tags="aeis${GOOS}" -o ${BUILD_DIR_PATH}/${BIN} ${MAKEFILE_PATH}/cmd/main.go
+	go build -a -ldflags "-s -w -X main.versionID=${VERSION} -X ${SELECTOR_PKG_VERSION_VAR}=${VERSION}" -tags="aeis${GOOS}" -o ${BUILD_DIR_PATH}/${BIN} ${MAKEFILE_PATH}/cmd/main.go
 
 clean:
 	rm -rf ${BUILD_DIR_PATH}/ && go clean -testcache ./...
@@ -110,5 +109,4 @@ release: build-binaries build-docker-images push-docker-images upload-resources-
 test: spellcheck shellcheck unit-test license-test go-report-card-test e2e-test output-validation-test readme-codeblock-test
 
 help:
-	@echo $(CURDIR)
 	@grep -E '^[a-zA-Z_-]+:.*$$' $(MAKEFILE_LIST) | sort

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <h4>A CLI tool and go library which recommends instance types based on resource criteria like vcpus and memory.</h4>
 
 <p>
-  <a href="https://golang.org/doc/go1.14">
+  <a href="https://golang.org/doc/go1.15">
     <img src="https://img.shields.io/github/go-mod/go-version/aws/amazon-ec2-instance-selector?color=blueviolet" alt="go-version">
   </a>
   <a href="https://opensource.org/licenses/Apache-2.0">

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/aws/amazon-ec2-instance-selector
 
-go 1.14
+go 1.15
 
 require (
 	github.com/aws/aws-sdk-go v1.31.12


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
 - Upgrade to go 1.15
    - Use GOPROXY piping to fallback to `direct` if the golang proxy returns an error
 - Add linker flags `-s -w` to strip debug table to make binary a little smaller


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
