### PR TITLE
fix tests by raising max-results

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ jobs:
   include:
     - stage: Test
       language: go
-      go: "1.14.x"
+      go: "1.15.x"
       script: make unit-test
       name: Unit Tests
       after_success: bash <(curl -s https://codecov.io/bash) -v
@@ -45,7 +45,7 @@ jobs:
     - stage: Test
       if: type = push AND env(GITHUB_TOKEN) IS present
       language: go
-      go: "1.14.x"
+      go: "1.15.x"
       script: make e2e-test
       name: E2E Tests
     - stage: Deploy

--- a/test/e2e/run-test
+++ b/test/e2e/run-test
@@ -6,6 +6,7 @@ BUILD_DIR="${SCRIPTPATH}/../../build"
 TEST_FAILURES_LOG="${BUILD_DIR}/test-failures.log"
 
 AEIS="${BUILD_DIR}/ec2-instance-selector"
+GLOBAL_PARAMS="--max-results=40"
 
 ## Print to stderr
 function echoerr() {
@@ -59,7 +60,7 @@ function execute_test() {
     echo "=========================== Test: ${test_name} ==========================="
 
     for p in "${params[@]}"; do
-        if $AEIS ${p} | assert_contains_instance_types "${expected[*]}"; then  
+        if $AEIS ${p} ${GLOBAL_PARAMS} | assert_contains_instance_types "${expected[*]}"; then  
             echo "✅ ${test_name} \"$p\" passed!"
         else
             echo "❌ Failed ${test_name} \"$p\"" | tee "${TEST_FAILURES_LOG}"


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
 - e2e tests were failing because max-results was truncating some of the expected values
 - Raised go version in travis.yml for unit-tests, missed this in the last PR to move to go 1.15. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
