### PR TITLE
show message on stderr when results have been truncated

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -94,6 +94,8 @@ var (
 func main() {
 
 	log.SetOutput(os.Stderr)
+	log.SetPrefix("NOTE: ")
+	log.SetFlags(log.Flags() &^ (log.Ldate | log.Ltime))
 
 	shortUsage := "A tool to filter EC2 Instance Types based on various resource criteria"
 	longUsage := binName + ` is a CLI tool to filter EC2 instance types based on resource criteria. 
@@ -232,7 +234,7 @@ Full docs can be found at github.com/aws/amazon-` + binName
 	outputFlag := cli.StringMe(flags[output])
 	outputFn := getOutputFn(outputFlag, selector.InstanceTypesOutputFn(resultsOutputFn))
 
-	instanceTypes, err := instanceSelector.FilterWithOutput(filters, outputFn)
+	instanceTypes, itemsTruncated, err := instanceSelector.FilterWithOutput(filters, outputFn)
 	if err != nil {
 		fmt.Printf("An error occurred when filtering instance types: %v", err)
 		os.Exit(1)
@@ -244,6 +246,10 @@ Full docs can be found at github.com/aws/amazon-` + binName
 
 	for _, instanceType := range instanceTypes {
 		fmt.Println(instanceType)
+	}
+
+	if itemsTruncated > 0 {
+		log.Printf("%d entries were truncated, increase --%s to see more", itemsTruncated, maxResults)
 	}
 }
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/amazon-ec2-instance-selector/issues/54

*Description of changes:*
 - Display a message if instance types were truncated from the output due to --max-results being set


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
