### PR TITLE
add release-automation targets

### DIFF
--- a/scripts/create-local-tag-for-release
+++ b/scripts/create-local-tag-for-release
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+# Script to create a new local tag in preparation for a release
+# This script is idempotent i.e. it always fetches remote tags to create the new tag.
+# E.g. If the current remote release tag is v1.0.0,
+## 1) running `create-local-tag-for-release -p` will create a new tag v1.0.1
+## 2) immediately running `create-local-tag-for-release -m` will create a new tag v2.0.0
+
+set -euo pipefail
+
+REPO_ROOT_PATH="$( cd "$(dirname "$0")"; cd ../; pwd -P )"
+MAKEFILE_PATH=$REPO_ROOT_PATH/Makefile
+TAG_REGEX="^v[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z]*)?$"
+
+HELP=$(cat << 'EOM'
+  Create a new local tag in preparation for a release. This script is idempotent i.e. it always fetches remote tags to create the new tag.
+
+  Usage: create-local-tag-for-release [options]
+
+  Options:
+    -v      new tag / version number. The script relies on the user to specify a valid and accurately incremented tag.
+    -m      increment major version
+    -i      increment minor version
+    -p      increment patch version
+    -h      help
+
+  Examples:
+    create-local-tag-for-release -v v1.0.0      Create local tag for new version v1.0.0
+    create-local-tag-for-release -i             Create local tag for new version by incrementing minor version only (previous tag=v1.0.0, new tag=v1.1.0)
+EOM
+)
+
+MAJOR_INC=false
+MINOR_INC=false
+PATCH_INC=false
+NEW_TAG=""
+CURR_REMOTE_RELEASE_TAG=""
+
+process_args() {
+    while getopts "hmipv:" opt; do
+        case ${opt} in
+            h )
+            echo -e "$HELP" 1>&2
+            exit 0
+            ;;
+            m )
+            MAJOR_INC=true
+            ;;
+            i )
+            MINOR_INC=true
+            ;;
+            p )
+            PATCH_INC=true
+            ;;
+            v )
+            NEW_TAG="${OPTARG}"
+            ;;
+            \? )
+            echo "$HELP" 1>&2
+            exit 0
+            ;;
+        esac
+    done
+}
+
+validate_args() {
+    if [[ ! -z $NEW_TAG ]]; then
+        if ! [[ $NEW_TAG =~ $TAG_REGEX ]]; then
+            echo "❌ Invalid new tag specified $NEW_TAG. Examples: v1.2.3, v1.2.3-dirty"
+            exit 1
+        fi
+
+        echo "🥑 Using the new tag specified with -v flag. All other flags, if specified, will be ignored."
+        echo "   NOTE:The script relies on the user to specify a valid and accurately incremented tag."
+        return
+    fi
+
+    if ($MAJOR_INC && $MINOR_INC) || ($MAJOR_INC && $PATCH_INC) || ($MINOR_INC && $PATCH_INC); then
+        echo "❌ Invalid arguments passed. Specify only one of 3 tag parts to increment for the new tag: -m (major) or -i (minor) or -p (patch)."
+        exit 1
+    fi
+
+    if $MAJOR_INC || $MINOR_INC || $PATCH_INC; then
+        return
+    fi
+
+    echo -e "❌ Invalid arguments passed. Specify atleast one argument.\n$HELP"
+    exit 1
+}
+
+sync_local_tags_from_remote() {
+    # setup remote upstream tracking to fetch tags
+    git remote add the-real-upstream https://github.com/aws/amazon-ec2-instance-selector.git &> /dev/null || true
+    git fetch the-real-upstream
+
+    # delete all local tags
+    git tag -l | xargs git tag -d
+
+    # fetch remote tags
+    git fetch the-real-upstream --tags
+
+    # record the latest release tag in remote, before creating a new tag
+    CURR_REMOTE_RELEASE_TAG=$(get_latest_tag)
+
+    # clean up tracking
+    git remote remove the-real-upstream
+}
+
+create_tag() {
+    git tag $NEW_TAG
+    echo -e "\n✅ Created new tag $NEW_TAG (Current latest release tag in remote: v$CURR_REMOTE_RELEASE_TAG)\n"
+    exit 0
+}
+
+get_latest_tag() {
+    make -s -f $MAKEFILE_PATH latest-release-tag | cut -b 2-
+}
+
+main() {
+    process_args "$@"
+    validate_args
+
+    sync_local_tags_from_remote
+
+    # if new tag is specified, create it
+    if [[ ! -z $NEW_TAG ]]; then
+        create_tag
+    fi
+
+    # increment version
+    if $MAJOR_INC || $MINOR_INC || $PATCH_INC; then
+        curr_major_v=$(echo $CURR_REMOTE_RELEASE_TAG | tr '.' '\n' | head -1)
+        curr_minor_v=$(echo $CURR_REMOTE_RELEASE_TAG | tr '.' '\n' | head -2 | tail -1)
+        curr_patch_v=$(echo $CURR_REMOTE_RELEASE_TAG | tr '.' '\n' | tail -1)
+
+        if [[ $MAJOR_INC == true ]]; then
+            new_major_v=$(echo $(($curr_major_v + 1)))
+            NEW_TAG=$(echo v$new_major_v.0.0)
+        elif [[ $MINOR_INC == true ]]; then
+            new_minor_v=$(echo $(($curr_minor_v + 1)))
+            NEW_TAG=$(echo v$curr_major_v.$new_minor_v.0)
+        elif [[ $PATCH_INC == true ]]; then
+            new_patch_v=$(echo $(($curr_patch_v + 1)))
+            NEW_TAG=$(echo v$curr_major_v.$curr_minor_v.$new_patch_v)
+        fi
+        create_tag
+    fi
+}
+
+main "$@"

--- a/scripts/prepare-for-release
+++ b/scripts/prepare-for-release
@@ -1,0 +1,235 @@
+#!/bin/bash
+
+# Script to:
+## 1) create and checkout a new branch with the latest tag name
+## 2) update instance-selector versions
+## 3) commit release prep changes to new branch
+## 4) create a PR from the new branch to upstream/main
+
+set -euo pipefail
+
+REPO_ROOT_PATH="$( cd "$(dirname "$0")"; cd ../; pwd -P )"
+MAKEFILE_PATH=$REPO_ROOT_PATH/Makefile
+LATEST_VERSION=$(make -s -f $MAKEFILE_PATH latest-release-tag | cut -b 2- )
+PREVIOUS_VERSION=$(make -s -f $MAKEFILE_PATH previous-release-tag | cut -b 2- )
+
+# files with versions, to update
+REPO_README=$REPO_ROOT_PATH/README.md
+FILES=("$REPO_README")
+FILES_CHANGED=()
+
+# release prep
+LATEST_TAG="v$LATEST_VERSION"
+NEW_BRANCH="pr/$LATEST_TAG-release"
+COMMIT_MESSAGE="🥑🤖 $LATEST_TAG release prep 🤖🥑"
+
+# PR details
+DEFAULT_REPO_FULL_NAME=$(make -s -f $MAKEFILE_PATH repo-full-name)
+PR_BASE=main  # target
+PR_TITLE="🥑🤖 $LATEST_TAG release prep"
+PR_BODY="🥑🤖 Auto-generated PR for $LATEST_TAG release. Updating release versions in repo."
+PR_LABEL_1="release-prep"
+PR_LABEL_2="🤖 auto-generated🤖"
+
+HELP=$(cat << 'EOM'
+  Update repo with the new release version and create a pr from a new release prep branch.
+  This script prompts the user with complete details about the PR before pushing the new local branch to remote and creating the PR.
+  The new release version is the latest local git tag.
+  Note: The local tag creation for a new release is separated from this script. A new tag must be created before this script is run which is automated when this script is run via make targets. 
+
+  Usage: prepare-for-release [options]
+
+  Options:
+    -d      create a draft pr
+    -r      target repo full name for the pr (default: aws/amazon-ec2-instance-selector)
+    -h      help
+
+  Examples:
+    prepare-for-release -d                                          update release version in repo and create a draft pr against aws/amazon-ec2-instance-selector
+    prepare-for-release -r username/amazon-ec2-instance-selector    update release version in repo and create a pr against username/amazon-ec2-instance-selector
+EOM
+)
+
+DRAFT=false
+REPO_FULL_NAME=""
+NEED_ROLLBACK=true
+
+process_args() {
+    while getopts "hdr:" opt; do
+        case ${opt} in
+            h )
+            echo -e "$HELP" 1>&2
+            exit 0
+            ;;
+            d )
+            DRAFT=true
+            ;;
+            r )
+            # todo: validate $REPO_FULL_NAME
+            REPO_FULL_NAME="${OPTARG}"
+            ;;
+            \? )
+            echo "$HELP" 1>&2
+            exit 0
+            ;;
+        esac
+    done
+
+    # set repo full name to the default value if unset
+    if [ -z $REPO_FULL_NAME ]; then
+        REPO_FULL_NAME=$DEFAULT_REPO_FULL_NAME
+    fi
+}
+
+# output formatting
+export TERM="xterm"
+RED=$(tput setaf 1)
+MAGENTA=$(tput setaf 5)
+RESET_FMT=$(tput sgr 0)
+BOLD=$(tput bold)
+
+# verify origin tracking before creating and pushing new branches
+verify_origin_tracking() {
+    origin=$(git remote get-url origin 2>&1) || true
+
+    if [[ $origin == "fatal: No such remote 'origin'" ]] || [[ $origin == "https://github.com/aws/amazon-ec2-instance-selector.git" ]]; then
+        echo -e "❌ ${RED}Expected remote 'origin' to be tracking fork but found \"$origin\". Set it up before running this script again.${RESET_FMT}"
+        NEED_ROLLBACK=false
+        exit 1
+    fi
+}
+
+create_release_branch() {
+    exists=$(git checkout -b $NEW_BRANCH 2>&1) || true
+
+    if [[ $exists == "fatal: A branch named '$NEW_BRANCH' already exists." ]]; then
+        echo -e "❌ ${RED}$exists${RESET_FMT}"
+        NEED_ROLLBACK=false
+        exit 1
+    fi
+    echo -e "✅ ${BOLD}Created new release branch $NEW_BRANCH\n\n${RESET_FMT}"
+}
+
+update_versions() {
+    # update release version for release prep
+    echo -e "🥑 Attempting to update instance-selector release version in preparation for a new release."
+
+    for f in "${FILES[@]}"; do
+        has_incorrect_version=$(cat $f | grep $PREVIOUS_VERSION)
+        if [[ ! -z  $has_incorrect_version ]]; then
+            sed -i '' "s/$PREVIOUS_VERSION/$LATEST_VERSION/g" $f
+            FILES_CHANGED+=("$f")
+        fi
+    done
+
+    if [[ ${#FILES_CHANGED[@]} -eq 0 ]]; then
+        echo -e "\nNo files were modified. Either all files already use git the latest release version $LATEST_VERSION or the files don't currently have the previous version $PREVIOUS_VERSION."
+    else
+        echo -e "✅✅ ${BOLD}Updated versions from $PREVIOUS_VERSION to $LATEST_VERSION in files: \n$(echo "${FILES_CHANGED[@]}" | tr ' ' '\n')"
+        echo -e "To see changes, run \`git diff HEAD^ HEAD\`${RESET_FMT}"
+    fi
+    echo
+}
+
+commit_changes() {
+    echo -e "\n🥑 Adding and committing release version changes."
+    git add "${FILES_CHANGED[@]}"
+    git commit -m"$COMMIT_MESSAGE"
+    echo -e "✅✅✅ ${BOLD}Committed release prep changes to new branch $NEW_BRANCH with commit message '$COMMIT_MESSAGE'\n\n${RESET_FMT}"
+}
+
+confirm_with_user_and_create_pr(){
+    git checkout $NEW_BRANCH # checkout new branch before printing git diff
+
+    echo -e "\n🥑${BOLD}The following PR will be created:\n"
+    cat << EOM
+    PR draft mode: $DRAFT
+    PR target repository: $REPO_FULL_NAME
+    PR source branch: $NEW_BRANCH
+    PR target branch: $REPO_FULL_NAME/$PR_BASE
+    PR title: $PR_TITLE
+    PR body: $PR_BODY
+    PR labels: $PR_LABEL_1, $PR_LABEL_2
+    Changes in $NEW_BRANCH:
+    ${MAGENTA}$(git diff HEAD^ HEAD)${RESET_FMT}
+EOM
+    while true; do
+        read -p "🥑${BOLD}Do you wish to create the release prep PR? Enter y/n  " yn
+        case $yn in
+            [Yy]* ) create_pr; break;;
+            [Nn]* ) rollback; exit;;
+            * ) echo "🥑Please answer yes or no.";;
+        esac
+    done
+    echo "${RESET_FMT}"
+}
+
+create_pr() {
+    git push -u origin $NEW_BRANCH # sets source branch for PR to NEW_BRANCH on the fork or origin
+    git checkout $NEW_BRANCH # checkout new branch before creating a pr
+
+    if [[ $DRAFT == true ]]; then
+        gh pr create \
+            --repo "$REPO_FULL_NAME" \
+            --base "$PR_BASE" \
+            --title "$PR_TITLE" \
+            --body "$PR_BODY" \
+            --label "$PR_LABEL_1" --label "$PR_LABEL_2" \
+            --draft
+    else
+        gh pr create \
+            --repo "$REPO_FULL_NAME" \
+            --base "$PR_BASE" \
+            --title "$PR_TITLE" \
+            --body "$PR_BODY" \
+            --label "$PR_LABEL_1" --label "$PR_LABEL_2"
+    fi
+
+    if [[ $? == 0 ]]; then
+        echo -e "✅✅✅✅ ${BOLD}Created $LATEST_TAG release prep PR\n${RESET_FMT}"
+    else
+        echo -e "❌ ${RED}PR creation failed.${RESET_FMT}❌"
+        exit 1
+    fi
+}
+
+# rollback partial changes to make this script atomic, iff the current execution of the script created a new branch and made changes
+rollback() {
+    if [[ $NEED_ROLLBACK == true ]]; then
+        echo "🥑${BOLD}Rolling back"
+
+        # checkout of current branch to main
+        git checkout main
+
+        # delete local and remote release branch only if current execution of the script created them
+        git branch -D $NEW_BRANCH
+        git push origin --delete $NEW_BRANCH
+    fi
+    echo "${RESET_FMT}"
+}
+
+handle_errors() {
+    # error handling
+    if [ $1 != "0" ]; then
+        FAILED_COMMAND=${*:2}
+        echo -e "\n❌ ${RED}Error occurred while running command '$FAILED_COMMAND'.${RESET_FMT}❌"
+        rollback
+        exit 1
+    fi
+    exit $1
+}
+
+main() {
+    process_args "$@"
+    trap 'handle_errors $? $BASH_COMMAND' EXIT
+
+    verify_origin_tracking
+
+    echo -e "🥑 Attempting to create a release prep branch and PR with release version updates.\n   Previous version: $PREVIOUS_VERSION ---> Latest version: $LATEST_VERSION"
+    create_release_branch
+    update_versions
+    commit_changes
+    confirm_with_user_and_create_pr
+}
+
+main "$@"


### PR DESCRIPTION
*Issue #, if available:*
* N/A

*Description of changes:*
* adding `make` targets for release automation
* mostly for release consistency across repos as this only updates the version in *ReadMe* for now

*Testing:*
* >make release-prep-minor

![image](https://user-images.githubusercontent.com/61433408/98731440-5afa0000-2363-11eb-94a5-3238ca1797dd.png)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
