### PR TITLE
add output option for one-line comma separated

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,7 +23,6 @@ import (
 	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector"
 	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector/outputs"
 	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/ec2"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"gopkg.in/ini.v1"
@@ -271,13 +270,7 @@ func getOutputFn(outputFlag *string, currentFn selector.InstanceTypesOutputFn) s
 		case tableOutput:
 			return selector.InstanceTypesOutputFn(outputs.TableOutputShort)
 		case oneLine:
-			return selector.InstanceTypesOutputFn(func(instanceTypeInfoSlice []*ec2.InstanceTypeInfo) []string {
-				instanceTypeNames := []string{}
-				for _, instanceType := range instanceTypeInfoSlice {
-					instanceTypeNames = append(instanceTypeNames, *instanceType.InstanceType)
-				}
-				return []string{strings.Join(instanceTypeNames, ",")}
-			})
+			return selector.InstanceTypesOutputFn(outputs.OneLineOutput)
 		}
 	}
 	return outputFn

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector"
 	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector/outputs"
 	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/ec2"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"gopkg.in/ini.v1"
@@ -42,6 +43,7 @@ const (
 	terraformHCL    = "terraform-hcl"
 	tableOutput     = "table"
 	tableWideOutput = "table-wide"
+	oneLine         = "one-line"
 )
 
 // Filter Flag Constants
@@ -110,6 +112,7 @@ Full docs can be found at github.com/aws/amazon-` + binName
 	cliOutputTypes := []string{
 		tableOutput,
 		tableWideOutput,
+		oneLine,
 	}
 	resultsOutputFn := outputs.SimpleInstanceTypeOutput
 
@@ -267,6 +270,14 @@ func getOutputFn(outputFlag *string, currentFn selector.InstanceTypesOutputFn) s
 			return selector.InstanceTypesOutputFn(outputs.TableOutputWide)
 		case tableOutput:
 			return selector.InstanceTypesOutputFn(outputs.TableOutputShort)
+		case oneLine:
+			return selector.InstanceTypesOutputFn(func(instanceTypeInfoSlice []*ec2.InstanceTypeInfo) []string {
+				instanceTypeNames := []string{}
+				for _, instanceType := range instanceTypeInfoSlice {
+					instanceTypeNames = append(instanceTypeNames, *instanceType.InstanceType)
+				}
+				return []string{strings.Join(instanceTypeNames, ",")}
+			})
 		}
 	}
 	return outputFn

--- a/pkg/selector/outputs/outputs.go
+++ b/pkg/selector/outputs/outputs.go
@@ -260,3 +260,15 @@ func TableOutputWide(instanceTypeInfoSlice []*ec2.InstanceTypeInfo) []string {
 	w.Flush()
 	return []string{buf.String()}
 }
+
+// OneLineOutput is an output function which prints the instance type names on a single line separated by commas
+func OneLineOutput(instanceTypeInfoSlice []*ec2.InstanceTypeInfo) []string {
+	instanceTypeNames := []string{}
+	for _, instanceType := range instanceTypeInfoSlice {
+		instanceTypeNames = append(instanceTypeNames, *instanceType.InstanceType)
+	}
+	if len(instanceTypeNames) == 0 {
+		return []string{}
+	}
+	return []string{strings.Join(instanceTypeNames, ",")}
+}

--- a/pkg/selector/outputs/outputs_test.go
+++ b/pkg/selector/outputs/outputs_test.go
@@ -129,3 +129,16 @@ func TestTableOutput_MBtoGB(t *testing.T) {
 	outputStr = strings.Join(instanceTypeOut, "")
 	h.Assert(t, strings.Contains(outputStr, "15.000"), "table should include 15.000 GB of memory")
 }
+
+func TestOneLineOutput(t *testing.T) {
+	instanceTypes := getInstanceTypes(t, "t3_micro_and_p3_16xl.json")
+	instanceTypeOut := outputs.OneLineOutput(instanceTypes)
+	h.Assert(t, len(instanceTypeOut) == 1, "Should always return 1 line")
+	h.Assert(t, instanceTypeOut[0] == "t3.micro,p3.16xlarge", "Should return both instance types separated by a comma")
+
+	instanceTypeOut = outputs.OneLineOutput([]*ec2.InstanceTypeInfo{})
+	h.Assert(t, len(instanceTypeOut) == 0, "Should return 0 instance types when passed empty slice")
+
+	instanceTypeOut = outputs.OneLineOutput(nil)
+	h.Assert(t, len(instanceTypeOut) == 0, "Should return 0 instance types when passed nil")
+}


### PR DESCRIPTION
Issue #, if available:
https://www.youtube.com/watch?v=9A2Zyxy2Nsk
As requested by @rothgar

Description of changes:
Add a 'one-line' output option so that you can easily use this in a subshell to other provisioning CLIs

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
