### PR TITLE
[WIP] Add Spot/On-demand price to table-wide output irrespective of the price filters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
 ### Go ###
+# IDE
+.idea
+
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/go.mod
+++ b/go.mod
@@ -12,5 +12,6 @@ require (
 	github.com/smartystreets/goconvey v1.6.4 // indirect
 	github.com/spf13/cobra v0.0.7
 	github.com/spf13/pflag v1.0.3
+	go.uber.org/multierr v1.1.0
 	gopkg.in/ini.v1 v1.57.0
 )

--- a/go.sum
+++ b/go.sum
@@ -116,7 +116,9 @@ github.com/ugorji/go v1.1.4/go.mod h1:uQMGLiO92mf5W77hV/PUCpI3pbzQx3CRekS0kk+RGr
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xordataexchange/crypt v0.0.3-0.20170626215501-b2862e3d0a77/go.mod h1:aYKd//L2LvnjZzWKhF00oedf4jCCReLcmhLdhm1A27Q=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
+go.uber.org/atomic v1.4.0 h1:cxzIVoETapQEqDhQu3QfnvXAV4AlzcvUCxkVUFw3+EU=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
+go.uber.org/multierr v1.1.0 h1:HoEmRHQPVSqub6w2z2d2EOVs2fjyFRGyofhKuyDq0QI=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=

--- a/pkg/selector/selector_test.go
+++ b/pkg/selector/selector_test.go
@@ -21,6 +21,7 @@ import (
 	"regexp"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/bytequantity"
 	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector"
@@ -599,6 +600,8 @@ type ec2PricingMock struct {
 	GetSpotInstanceTypeNDayAvgCostErr  error
 	HydrateOndemandCacheErr            error
 	HydrateSpotCacheErr                error
+	lastOnDemandCachedUTC              *time.Time
+	lastSpotCachedUTC                  *time.Time
 }
 
 func (p *ec2PricingMock) GetOndemandInstanceTypeCost(instanceType string) (float64, error) {
@@ -615,6 +618,14 @@ func (p *ec2PricingMock) HydrateOndemandCache() error {
 
 func (p *ec2PricingMock) HydrateSpotCache(days int) error {
 	return p.HydrateSpotCacheErr
+}
+
+func (p *ec2PricingMock) LastOnDemandCachedUTC() *time.Time {
+	return p.lastOnDemandCachedUTC
+}
+
+func (p *ec2PricingMock) LastSpotCachedUTC() *time.Time {
+	return p.lastSpotCachedUTC
 }
 
 func TestFilter_PricePerHour(t *testing.T) {


### PR DESCRIPTION
## Side effects:
* Minor clean-up
* Update `.gitignore`
* Add dependency `go.uber.org/multierr v1.1.0`

## Issue, if available:
#71 

## Description of changes:
To show Spot and On Demand prices in table wide output irrespective of the price filters being set; if the filters are set, do filtration normally depending on usage class. For other output modes, do filtration normally depending on usage class.

## Testing:
#### Table wide output - us-east-1 (both cache was hydrated)
```
Krishna-Birla:amazon-ec2-instance-selector krishna.birla$ ./build/ec2-instance-selector -o table-wide --region us-east-1 --max-results 10
Instance Type  VCPUs   Mem (GiB)  Hypervisor  Current Gen  Hibernation Support  CPU Arch      Network Performance  ENIs    GPUs    GPU Mem (GiB)  GPU Info  On-Demand Price/Hr  Spot Price/Hr (30d avg)
-------------  -----   ---------  ----------  -----------  -------------------  --------      -------------------  ----    ----    -------------  --------  ------------------  -----------------------
a1.2xlarge     8       16         nitro       false        false                arm64         Up to 10 Gigabit     4       0       0                        $0.204              $0.06769
a1.4xlarge     16      32         nitro       false        false                arm64         Up to 10 Gigabit     8       0       0                        $0.408              $0.1343
a1.large       2       4          nitro       false        false                arm64         Up to 10 Gigabit     3       0       0                        $0.051              $0.01694
a1.medium      1       2          nitro       false        false                arm64         Up to 10 Gigabit     2       0       0                        $0.0255             $0.0084
a1.metal       16      32         none        false        false                arm64         Up to 10 Gigabit     8       0       0                        $0.408              $0.1343
a1.xlarge      4       8          nitro       false        false                arm64         Up to 10 Gigabit     4       0       0                        $0.102              $0.0336
c1.medium      2       1.69922    xen         false        false                i386, x86_64  Moderate             2       0       0                        $0.13               $0.01402
c1.xlarge      8       7          xen         false        false                x86_64        High                 4       0       0                        $0.52               $0.11083
c3.2xlarge     8       15         xen         false        true                 x86_64        High                 4       0       0                        $0.42               $0.13062
c3.4xlarge     16      30         xen         false        true                 x86_64        High                 8       0       0                        $0.84               $0.31342
NOTE: 373 entries were truncated, increase --max-results to see more
```
#### Table wide output - ap-south-1 (both cache was hydrated)
```
Krishna-Birla:amazon-ec2-instance-selector krishna.birla$ ./build/ec2-instance-selector -o table-wide --region ap-south-1 --max-results 10
Instance Type  VCPUs   Mem (GiB)  Hypervisor  Current Gen  Hibernation Support  CPU Arch  Network Performance  ENIs    GPUs    GPU Mem (GiB)  GPU Info  On-Demand Price/Hr  Spot Price/Hr (30d avg)
-------------  -----   ---------  ----------  -----------  -------------------  --------  -------------------  ----    ----    -------------  --------  ------------------  -----------------------
a1.2xlarge     8       16         nitro       false        false                arm64     Up to 10 Gigabit     4       0       0                        $0.204              $0.0547
a1.4xlarge     16      32         nitro       false        false                arm64     Up to 10 Gigabit     8       0       0                        $0.408              $0.1095
a1.large       2       4          nitro       false        false                arm64     Up to 10 Gigabit     3       0       0                        $0.051              $0.0137
a1.medium      1       2          nitro       false        false                arm64     Up to 10 Gigabit     2       0       0                        $0.0255             $0.0068
a1.metal       16      32         none        false        false                arm64     Up to 10 Gigabit     8       0       0                        $0.408              $0.1095
a1.xlarge      4       8          nitro       false        false                arm64     Up to 10 Gigabit     4       0       0                        $0.102              $0.0274
c4.2xlarge     8       15         xen         true         true                 x86_64    High                 4       0       0                        $0.4                $0.12467
c4.4xlarge     16      30         xen         true         true                 x86_64    High                 8       0       0                        $0.8                $0.20867
c4.8xlarge     36      60         xen         true         true                 x86_64    10 Gigabit           8       0       0                        $1.6                $0.42315
c4.large       2       3.75       xen         true         true                 x86_64    Moderate             3       0       0                        $0.1                $0.02553
NOTE: 226 entries were truncated, increase --max-results to see more
```
#### Table output - ap-south-1 (both cache was NOT hydrated)
```
Krishna-Birla:amazon-ec2-instance-selector krishna.birla$ ./build/ec2-instance-selector -o table --region ap-south-1 --max-results 10
Instance Type        VCPUs        Mem (GiB)
-------------        -----        ---------
a1.2xlarge           8            16
a1.4xlarge           16           32
a1.large             2            4
a1.medium            1            2
a1.metal             16           32
a1.xlarge            4            8
c4.2xlarge           8            15
c4.4xlarge           16           30
c4.8xlarge           36           60
c4.large             2            3.75
NOTE: 226 entries were truncated, increase --max-results to see more
```
#### Table wide output with price filter - ap-south-1 (both cache was hydrated)
```
Krishna-Birla:amazon-ec2-instance-selector krishna.birla$ ./build/ec2-instance-selector -o table-wide --region ap-south-1 --max-results 10 --price-per-hour 0.0255
Instance Type  VCPUs   Mem (GiB)  Hypervisor  Current Gen  Hibernation Support  CPU Arch  Network Performance  ENIs    GPUs    GPU Mem (GiB)  GPU Info  On-Demand Price/Hr  Spot Price/Hr (30d avg)
-------------  -----   ---------  ----------  -----------  -------------------  --------  -------------------  ----    ----    -------------  --------  ------------------  -----------------------
a1.medium      1       2          nitro       false        false                arm64     Up to 10 Gigabit     2       0       0                        $0.0255             $0.0068
```
#### Table wide output with price filter and usage class - ap-south-1 (both cache was hydrated)
```
Krishna-Birla:amazon-ec2-instance-selector krishna.birla$ ./build/ec2-instance-selector -o table-wide --region ap-south-1 --max-results 10 --price-per-hour 0.0068 --usage-class spot
Instance Type  VCPUs   Mem (GiB)  Hypervisor  Current Gen  Hibernation Support  CPU Arch  Network Performance  ENIs    GPUs    GPU Mem (GiB)  GPU Info  On-Demand Price/Hr  Spot Price/Hr (30d avg)
-------------  -----   ---------  ----------  -----------  -------------------  --------  -------------------  ----    ----    -------------  --------  ------------------  -----------------------
a1.medium      1       2          nitro       false        false                arm64     Up to 10 Gigabit     2       0       0                        $0.0255             $0.0068
```
#### Table wide output with price range filter - ap-south-1 (both cache was hydrated)
```
Krishna-Birla:amazon-ec2-instance-selector krishna.birla$ ./build/ec2-instance-selector -o table-wide --region ap-south-1 --max-results 10 --price-per-hour-min 0.19 --price-per-hour-max 0.26
Instance Type  VCPUs   Mem (GiB)  Hypervisor  Current Gen  Hibernation Support  CPU Arch  Network Performance  ENIs    GPUs    GPU Mem (GiB)  GPU Info  On-Demand Price/Hr  Spot Price/Hr (30d avg)
-------------  -----   ---------  ----------  -----------  -------------------  --------  -------------------  ----    ----    -------------  --------  ------------------  -----------------------
a1.2xlarge     8       16         nitro       false        false                arm64     Up to 10 Gigabit     4       0       0                        $0.204              $0.0547
c4.xlarge      4       7.5        xen         true         true                 x86_64    High                 4       0       0                        $0.2                $0.05675
c5d.xlarge     4       8          nitro       true         false                x86_64    Up to 10 Gigabit     4       0       0                        $0.198              $0.05407
c5n.xlarge     4       10.5       nitro       true         false                x86_64    Up to 25 Gigabit     4       0       0                        $0.216              $0.0541
i3en.large     2       16         nitro       true         false                x86_64    Up to 25 Gigabit     3       0       0                        $0.257              $0.0771
m4.xlarge      4       16         xen         true         true                 x86_64    High                 4       0       0                        $0.21               $0.05484
m5.xlarge      4       16         nitro       true         true                 x86_64    Up to 10 Gigabit     4       0       0                        $0.202              $0.05727
m5a.2xlarge    8       32         nitro       true         true                 x86_64    Up to 10 Gigabit     4       0       0                        $0.222              $0.13125
m5d.xlarge     4       16         nitro       true         false                x86_64    Up to 10 Gigabit     4       0       0                        $0.244              $0.05576
m6g.2xlarge    8       32         nitro       true         false                arm64     Up to 10 Gigabit     4       0       0                        $0.2024             $0.11782
NOTE: 6 entries were truncated, increase --max-results to see more
```
#### Table output with price range filter - ap-south-1 (only on-demand cache was hydrated)
```
Krishna-Birla:amazon-ec2-instance-selector krishna.birla$ ./build/ec2-instance-selector -o table --region ap-south-1 --max-results 10 --price-per-hour-min 0.19 --price-per-hour-max 0.26
Instance Type        VCPUs        Mem (GiB)
-------------        -----        ---------
a1.2xlarge           8            16
c4.xlarge            4            7.5
c5d.xlarge           4            8
c5n.xlarge           4            10.5
i3en.large           2            16
m4.xlarge            4            16
m5.xlarge            4            16
m5a.2xlarge          8            32
m5d.xlarge           4            16
m6g.2xlarge          8            32
NOTE: 6 entries were truncated, increase --max-results to see more
```
#### Table wide output with price range filter and usage class - ap-south-1 (both cache was hydrated)
```
Krishna-Birla:amazon-ec2-instance-selector krishna.birla$ ./build/ec2-instance-selector -o table-wide --region ap-south-1 --max-results 10 --price-per-hour-min 0.03 --price-per-hour-max 0.16 --usage-class spot
Instance Type  VCPUs   Mem (GiB)  Hypervisor  Current Gen  Hibernation Support  CPU Arch  Network Performance  ENIs    GPUs    GPU Mem (GiB)  GPU Info  On-Demand Price/Hr  Spot Price/Hr (30d avg)
-------------  -----   ---------  ----------  -----------  -------------------  --------  -------------------  ----    ----    -------------  --------  ------------------  -----------------------
a1.2xlarge     8       16         nitro       false        false                arm64     Up to 10 Gigabit     4       0       0                        $0.204              $0.0547
a1.4xlarge     16      32         nitro       false        false                arm64     Up to 10 Gigabit     8       0       0                        $0.408              $0.1095
a1.metal       16      32         none        false        false                arm64     Up to 10 Gigabit     8       0       0                        $0.408              $0.1095
c4.2xlarge     8       15         xen         true         true                 x86_64    High                 4       0       0                        $0.4                $0.12467
c4.xlarge      4       7.5        xen         true         true                 x86_64    High                 4       0       0                        $0.2                $0.05677
c5.2xlarge     8       16         nitro       true         true                 x86_64    Up to 10 Gigabit     4       0       0                        $0.34               $0.12554
c5.large       2       4          nitro       true         true                 x86_64    Up to 10 Gigabit     3       0       0                        $0.085              $0.03303
c5.xlarge      4       8          nitro       true         true                 x86_64    Up to 10 Gigabit     4       0       0                        $0.17               $0.0553
c5a.2xlarge    8       16         nitro       true         false                x86_64    Up to 10 Gigabit     4       0       0                        $0.188              $0.11058
c5a.xlarge     4       8          nitro       true         false                x86_64    Up to 10 Gigabit     4       0       0                        $0.094              $0.05307
NOTE: 48 entries were truncated, increase --max-results to see more
```
#### Table output with price range filter and usage class - ap-south-1 (only spot cache was hydrated)
```
Krishna-Birla:amazon-ec2-instance-selector krishna.birla$ ./build/ec2-instance-selector -o table --region ap-south-1 --max-results 10 --price-per-hour-min 0.03 --price-per-hour-max 0.16 --usage-class spot
Instance Type        VCPUs        Mem (GiB)
-------------        -----        ---------
a1.2xlarge           8            16
a1.4xlarge           16           32
a1.metal             16           32
c4.2xlarge           8            15
c4.xlarge            4            7.5
c5.2xlarge           8            16
c5.large             2            4
c5.xlarge            4            8
c5a.2xlarge          8            16
c5a.xlarge           4            8
NOTE: 48 entries were truncated, increase --max-results to see more
```

###### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
