### PR TITLE
fix pricing api endpoint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,6 @@ jobs:
       run: make homebrew-sync-dry-run
 
     - name: License Test
-      if: github.event_name == 'push' && contains(github.ref, 'refs/tags/')
       run: make license-test
 
     - name: Build Binaries

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 # Build the manager binary
-FROM golang:1.16 as builder
+FROM public.ecr.aws/bitnami/golang:1.16 as builder
 
 ## GOLANG env
-ARG GOPROXY="https://proxy.golang.org|direct"
-ARG GO111MODULE="on"
-ARG CGO_ENABLED=0
-ARG GOOS=linux 
-ARG GOARCH=amd64 
+ENV GOPROXY="https://proxy.golang.org|direct"
+ENV GO111MODULE="on"
+ENV CGO_ENABLED=0
+ENV GOOS=linux 
+ENV GOARCH=amd64 
 
 # Copy go.mod and download dependencies
 WORKDIR /amazon-ec2-instance-selector

--- a/pkg/ec2pricing/ec2pricing.go
+++ b/pkg/ec2pricing/ec2pricing.go
@@ -48,7 +48,8 @@ type spotPricingEntry struct {
 // New creates an instance of instance-selector EC2Pricing
 func New(sess *session.Session) *EC2Pricing {
 	return &EC2Pricing{
-		PricingClient: pricing.New(sess),
+                // use us-east-1 since pricing only has endpoints in us-east-1 and ap-south-1
+		PricingClient: pricing.New(sess.Copy(aws.NewConfig().WithRegion("us-east-1"))),
 		EC2Client:     ec2.New(sess),
 		AWSSession:    sess,
 	}

--- a/test/go-report-card-test/Dockerfile
+++ b/test/go-report-card-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1
+FROM public.ecr.aws/bitnami/golang:latest
 
 WORKDIR /app
 

--- a/test/go-report-card-test/run-report-card-test.sh
+++ b/test/go-report-card-test/run-report-card-test.sh
@@ -20,6 +20,6 @@ else
 fi
 
 
-docker run -t -v $SCRIPTPATH/../../:/app go-report-card-cli /go/bin/goreportcard-cli -v -t $THRESHOLD
+docker run -v $SCRIPTPATH/../../:/app go-report-card-cli /go/bin/goreportcard-cli -v -t $THRESHOLD
 
 exit $EXIT_CODE

--- a/test/license-test/Dockerfile
+++ b/test/license-test/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1
+FROM public.ecr.aws/bitnami/golang:latest
 
 WORKDIR /app
 

--- a/test/license-test/run-license-test.sh
+++ b/test/license-test/run-license-test.sh
@@ -13,4 +13,4 @@ SUPPORTED_PLATFORMS="$OS/$ARCH" make -f $SCRIPTPATH/../../Makefile build-binarie
 
 SUPPORTED_PLATFORMS="$OS/$ARCH" make -s -f $SCRIPTPATH/../../Makefile build-binaries
 docker build --build-arg=GOPROXY=direct -t $LICENSE_TEST_TAG $SCRIPTPATH/
-docker run -it -e GITHUB_TOKEN --rm -v $SCRIPTPATH/:/test -v $BUILD_BIN/:/aeis-bin $LICENSE_TEST_TAG golicense /test/license-config.hcl /aeis-bin/$BINARY_NAME
+docker run -i -e GITHUB_TOKEN --rm -v $SCRIPTPATH/:/test -v $BUILD_BIN/:/aeis-bin $LICENSE_TEST_TAG golicense /test/license-config.hcl /aeis-bin/$BINARY_NAME


### PR DESCRIPTION
Issue #, if available:
N/A
 
Description of changes:
 - Fix pricing client to use global endpoint since they do not offer regional endpoints
 - Use AWS ECR gallery rather than dockerhub for golang image to avoid dockerhub rate limiting
 - Run license test on PRs too since Github Actions automatically injects a read-only GITHUB_TOKEN in PR GA runs. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
