### PR TITLE
add aws creds and test targets to gh actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,10 @@ on: [push, pull_request, workflow_dispatch]
 
 env:
   DEFAULT_GO_VERSION: ^1.16
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
+  AWS_REGION: ${{ secrets.AWS_REGION }}
   GITHUB_USERNAME: ${{ secrets.EC2_BOT_GITHUB_USERNAME }}
   GITHUB_TOKEN: ${{ secrets.EC2_BOT_GITHUB_TOKEN }}
   DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -38,6 +42,15 @@ jobs:
 
     - name: License Test
       run: make license-test
+
+    - name: E2E Tests
+      run: make e2e-test
+
+    - name: ReadMe Tests
+      run: make readme-codeblock-test
+
+    - name: Output Validation Tests
+      run: make output-validation-test
 
     - name: Build Binaries
       run: make build-binaries

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ sync-readme-to-dockerhub:
 unit-test:
 	go test -bench=. ${MAKEFILE_PATH}/...  -v -coverprofile=coverage.out -covermode=atomic -outputdir=${BUILD_DIR_PATH}
 
+## requires aws credentials
 e2e-test: build
 	${MAKEFILE_PATH}/test/e2e/run-test
 


### PR DESCRIPTION
Adding aws creds to GitHub Actions file. These are used for running tests requiring credentials. 

*Note: `AWS_REGION` is needed for e2e tests to pass*



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
