### PR TITLE
Ghactions update

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,10 +4,6 @@ on: [push, pull_request, workflow_dispatch]
 
 env:
   DEFAULT_GO_VERSION: ^1.16
-  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-  AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
-  AWS_REGION: ${{ secrets.AWS_REGION }}
   GITHUB_USERNAME: ${{ secrets.EC2_BOT_GITHUB_USERNAME }}
   GITHUB_TOKEN: ${{ secrets.EC2_BOT_GITHUB_TOKEN }}
   DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -43,20 +39,20 @@ jobs:
     - name: License Test
       run: make license-test
 
-    - name: E2E Tests
-      run: make e2e-test
-
-    - name: ReadMe Tests
-      run: make readme-codeblock-test
-
-    - name: Output Validation Tests
-      run: make output-validation-test
-
     - name: Build Binaries
       run: make build-binaries
 
     - name: Build Docker Images
       run: make build-docker-images
+
+    - name: Integration Tests
+      if: github.event_name == 'push'
+      run: make integ-test
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
+        AWS_REGION: ${{ secrets.AWS_REGION }}
 
   release:
     name: Release

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,10 @@ on: [push, pull_request, workflow_dispatch]
 
 env:
   DEFAULT_GO_VERSION: ^1.16
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_SESSION_TOKEN: ${{ secrets.AWS_SESSION_TOKEN }}
+  AWS_REGION: ${{ secrets.AWS_REGION }}
   GITHUB_USERNAME: ${{ secrets.EC2_BOT_GITHUB_USERNAME }}
   GITHUB_TOKEN: ${{ secrets.EC2_BOT_GITHUB_TOKEN }}
   DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -38,6 +42,15 @@ jobs:
 
     - name: License Test
       run: make license-test
+
+    - name: E2E Tests
+      run: make e2e-test
+
+    - name: ReadMe Tests
+      run: make readme-codeblock-test
+
+    - name: Output Validation Tests
+      run: make output-validation-test
 
     - name: Build Binaries
       run: make build-binaries

--- a/Makefile
+++ b/Makefile
@@ -93,6 +93,7 @@ sync-readme-to-dockerhub:
 unit-test:
 	go test -bench=. ${MAKEFILE_PATH}/...  -v -coverprofile=coverage.out -covermode=atomic -outputdir=${BUILD_DIR_PATH}
 
+## requires aws credentials
 e2e-test: build
 	${MAKEFILE_PATH}/test/e2e/run-test
 

--- a/Makefile
+++ b/Makefile
@@ -97,6 +97,9 @@ unit-test:
 e2e-test: build
 	${MAKEFILE_PATH}/test/e2e/run-test
 
+## requires aws credentials
+integ-test: e2e-test output-validation-test readme-codeblock-test
+
 homebrew-sync-dry-run:
 	${MAKEFILE_PATH}/scripts/sync-to-aws-homebrew-tap -d -b ${BIN} -r ${REPO_FULL_NAME} -p ${SUPPORTED_PLATFORMS} -v ${LATEST_RELEASE_TAG}
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 <h4>A CLI tool and go library which recommends instance types based on resource criteria like vcpus and memory.</h4>
 
 <p>
-  <a href="https://golang.org/doc/go1.15">
+  <a href="https://golang.org/doc/go1.16">
     <img src="https://img.shields.io/github/go-mod/go-version/aws/amazon-ec2-instance-selector?color=blueviolet" alt="go-version">
   </a>
   <a href="https://opensource.org/licenses/Apache-2.0">


### PR DESCRIPTION
Adding aws creds to gh actions. These will be used to run tests requiring credentials.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
