### PR TITLE
Apple M1 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ GOARCH ?= amd64
 GOPROXY ?= "https://proxy.golang.org,direct"
 MAKEFILE_PATH = $(dir $(realpath -s $(firstword $(MAKEFILE_LIST))))
 BUILD_DIR_PATH = ${MAKEFILE_PATH}/build
-SUPPORTED_PLATFORMS ?= "windows/amd64,darwin/amd64,linux/amd64,linux/arm64,linux/arm"
+SUPPORTED_PLATFORMS ?= "windows/amd64,darwin/amd64,darwin/arm64,linux/amd64,linux/arm64,linux/arm"
 SELECTOR_PKG_VERSION_VAR=github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector.versionID
 LATEST_RELEASE_TAG=$(shell git describe --tags --abbrev=0)
 PREVIOUS_RELEASE_TAG=$(shell git describe --abbrev=0 --tags `git rev-list --tags --skip=1  --max-count=1`)

--- a/scripts/sync-to-aws-homebrew-tap
+++ b/scripts/sync-to-aws-homebrew-tap
@@ -163,7 +163,7 @@ for os_arch in "${PLATFORMS[@]}"; do
 
     if [[ "${os}" == "darwin" && "${arch}" == "amd64" ]]; then
       MAC_HASH=$(hash_file "${asset_file_path}")
-    if [[ "${os}" == "darwin" && "${arch}" == "arm64" ]]; then
+    elif [[ "${os}" == "darwin" && "${arch}" == "arm64" ]]; then
       MAC_ARM64_HASH=$(hash_file "${asset_file_path}")
     elif [[ "${os}" == "linux" && "${arch}" == "amd64" ]]; then
       LINUX_HASH=$(hash_file "${asset_file_path}")

--- a/scripts/sync-to-aws-homebrew-tap
+++ b/scripts/sync-to-aws-homebrew-tap
@@ -125,6 +125,7 @@ mkdir -p "${DOWNLOAD_DIR}" "${SYNC_DIR}" "${BREW_CONFIG_DIR}"
 
 BASE_ASSET_URL="https://github.com/${REPO}/releases/download/${VERSION}/${BINARY_BASE}"
 MAC_HASH=""
+MAC_ARM64_HASH=""
 LINUX_HASH=""
 LINUX_ARM64_HASH=""
 
@@ -160,8 +161,10 @@ for os_arch in "${PLATFORMS[@]}"; do
       fi
     fi
 
-    if [[ "${os}" == "darwin" ]]; then
+    if [[ "${os}" == "darwin" && "${arch}" == "amd64" ]]; then
       MAC_HASH=$(hash_file "${asset_file_path}")
+    if [[ "${os}" == "darwin" && "${arch}" == "arm64" ]]; then
+      MAC_ARM64_HASH=$(hash_file "${asset_file_path}")
     elif [[ "${os}" == "linux" && "${arch}" == "amd64" ]]; then
       LINUX_HASH=$(hash_file "${asset_file_path}")
     elif [[ "${os}" == "linux" && "${arch}" == "arm64" ]]; then
@@ -178,6 +181,7 @@ cat << EOM > "${BREW_CONFIG_DIR}/${BINARY_BASE}.json"
     "bottle": {
         "root_url": "${BASE_ASSET_URL}",
         "sha256": {
+            "arm64_big_sur": "${MAC_ARM64_HASH}",
             "sierra": "${MAC_HASH}",
             "linux": "${LINUX_HASH}",
             "linux_arm": "${LINUX_ARM64_HASH}"
@@ -187,7 +191,7 @@ cat << EOM > "${BREW_CONFIG_DIR}/${BINARY_BASE}.json"
 EOM
 
 if [[ "${DRY_RUN}" -eq 0 ]]; then 
-  if [[ -z "${MAC_HASH}" ]] && [[ -z "${LINUX_HASH}" ]] && [[ -z "${LINUX_ARM64_HASH}" ]]; then 
+  if [[ -z "${MAC_HASH}" ]] && [[ -z "${MAC_ARM64_HASH}" ]] && [[ -z "${LINUX_HASH}" ]] && [[ -z "${LINUX_ARM64_HASH}" ]]; then 
     echo "❌ No hashes were calculated and dry-run is NOT engaged. Bailing out so we don't open a bad PR to the tap."
     exit 4
   fi


### PR DESCRIPTION
Description of changes:
Changes needed to enable native binaries for Apple M1 (arm64) silicon.

Note: For Homebrew support, this would need some updates on the `aws/homebrew-tap` formula, in addition to these changes. Specifically [here](https://github.com/aws/homebrew-tap/blob/master/Formula/ec2-instance-selector.rb#L13-L15).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
