### PR TITLE
fix docker layer caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
-# Build the manager binary
 FROM public.ecr.aws/bitnami/golang:1.17 as builder
 
 ## GOLANG env
 ARG GOPROXY="https://proxy.golang.org|direct"
 ARG GO111MODULE="on"
-ARG CGO_ENABLED=0
-ARG GOOS=linux 
-ARG GOARCH=amd64 
 
 # Copy go.mod and download dependencies
 WORKDIR /amazon-ec2-instance-selector
 COPY go.mod .
 COPY go.sum .
 RUN go mod download
+
+ARG CGO_ENABLED=0
+ARG GOOS=linux 
+ARG GOARCH=amd64 
 
 # Build
 COPY . .


### PR DESCRIPTION
## Issue #, if available:
N/a

## Description of changes:
Reduce build times by leveraging docker caching layers. Previously, go mod downloads were not cached between os/arch variants because the build args changed which resulted in docker invalidating the go mod download layer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
