### PR TITLE
Fix fetching EKS AMI release archive

### DIFF
--- a/pkg/selector/eks.go
+++ b/pkg/selector/eks.go
@@ -41,7 +41,7 @@ func (e *EKS) Filters(version string) (Filters, error) {
 	if e.AMIRepoURL == "" {
 		e.AMIRepoURL = eksAMIRepoURL
 	}
-	filters := Filters{}
+	var filters Filters
 
 	if version == "" {
 		var err error
@@ -50,9 +50,6 @@ func (e *EKS) Filters(version string) (Filters, error) {
 			log.Printf("There was a problem fetching the latest EKS AMI version, using hardcoded fallback version %s\n", eksFallbackLatestAMIVersion)
 			version = eksFallbackLatestAMIVersion
 		}
-	}
-	if !strings.HasPrefix(version, "v") {
-		version = fmt.Sprintf("v%s", version)
 	}
 	supportedInstanceTypes, err := e.getSupportedInstanceTypes(version)
 	if err != nil {
@@ -72,7 +69,7 @@ func (e *EKS) getSupportedInstanceTypes(version string) ([]string, error) {
 	}
 
 	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
+	if resp.StatusCode != http.StatusOK {
 		return supportedInstanceTypes, fmt.Errorf("Unable to retrieve EKS supported instance types, got non-200 status code: %d", resp.StatusCode)
 	}
 
@@ -119,7 +116,7 @@ func (e EKS) getLatestAMIVersion() (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if resp.StatusCode != 302 {
+	if resp.StatusCode != http.StatusFound {
 		return "", fmt.Errorf("Can't retrieve latest release from github because redirect was not sent")
 	}
 	versionRedirect := resp.Header.Get("location")


### PR DESCRIPTION
This changelist fixes fetching the EKS AMI release archive by removing the check for adding a `v` prefix if it does not exist.

The last release published a [tag](https://github.com/awslabs/amazon-eks-ami/releases/tag/V20220123) that begins with an uppercase `V` and the code ends up prepending an additional `v`, rendering the URL incorrect. Rather than accounting for this case in code, this changelist removes that check altogether as `amazon-eks-ami` has been consistently adding the `v` prefix to their tags.

Fixes #111 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
