### PR TITLE
Fix release script prompt when calling from a golang process

### DIFF
--- a/scripts/prepare-for-release
+++ b/scripts/prepare-for-release
@@ -154,7 +154,8 @@ confirm_with_user_and_create_pr(){
     ${MAGENTA}$(git diff HEAD^ HEAD)${RESET_FMT}
 EOM
     while true; do
-        read -p "🥑${BOLD}Do you wish to create the release prep PR? Enter y/n  " yn
+        echo -e "🥑${BOLD}Do you wish to create the release prep PR? Enter y/n"
+        read -p "" yn
         case $yn in
             [Yy]* ) create_pr; break;;
             [Nn]* ) rollback; exit;;


### PR DESCRIPTION

Issue #, if available: N/A

Description of changes:

For some reason, `read -p` doesn't properly print to stdout when invoked
by golang's `exec.Command().Run()`, but `echo` does. Reading from stdin
still works correctly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
