### PR TITLE
fixed issue with OD pricing for european regions

### DIFF
--- a/pkg/ec2pricing/odpricing.go
+++ b/pkg/ec2pricing/odpricing.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -214,6 +215,12 @@ func (c *OnDemandPricing) getRegionForPricingAPI() string {
 			regionDescription = region.Description()
 		}
 	}
+
+	// endpoints package returns European regions with the word "Europe," but the pricing API expects the word "EU."
+	// This formatting mismatch is only present with European regions.
+	// So replace "Europe" with "EU" if it exists in the regionDescription string.
+	regionDescription = strings.Replace(regionDescription, "Europe", "EU", 2)
+
 	return regionDescription
 }
 

--- a/pkg/ec2pricing/odpricing.go
+++ b/pkg/ec2pricing/odpricing.go
@@ -219,7 +219,7 @@ func (c *OnDemandPricing) getRegionForPricingAPI() string {
 	// endpoints package returns European regions with the word "Europe," but the pricing API expects the word "EU."
 	// This formatting mismatch is only present with European regions.
 	// So replace "Europe" with "EU" if it exists in the regionDescription string.
-	regionDescription = strings.Replace(regionDescription, "Europe", "EU", 2)
+	regionDescription = strings.ReplaceAll(regionDescription, "Europe", "EU")
 
 	return regionDescription
 }


### PR DESCRIPTION
**Issue #, if available:** #131

**Description of changes:**
getRegionForPricingAPI() (found in odpricing.go on line 206) was returning the wrong region description for all European regions. It was returning descriptions with the word "Europe" instead of "Eu," which was causing the pricing API (called on line 170) to be unable to fetch on demand pricing for European regions. 

I manually tested all region IDs and this formatting mismatch only seemed to occur with European regions, so to fix this issue, I used strings.Replace() to replace all mentions of "Europe" with "Eu" after the endpoint sdk found the correct region description based on the user's desired region ID. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
