### PR TITLE
CLI Instance Sorting

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,42 @@ t3.medium      2       4          nitro       true         true                 
 t3a.medium     2       4          nitro       true         true                 x86_64        Up to 5 Gigabit      3       0       0                        $0.0376             $0.01431
 ```
 
+**Sort by memory in descending order using JSON path**
+```
+$ ec2-instance-selector -r us-east-1 -o table-wide --max-results 10 --sort-by $.MemoryInfo.SizeInMiB --sort-direction desc
+Instance Type      VCPUs   Mem (GiB)  Hypervisor  Current Gen  Hibernation Support  CPU Arch  Network Performance  ENIs    GPUs    GPU Mem (GiB)  GPU Info  On-Demand Price/Hr  Spot Price/Hr (30d avg)  
+-------------      -----   ---------  ----------  -----------  -------------------  --------  -------------------  ----    ----    -------------  --------  ------------------  -----------------------  
+u-12tb1.112xlarge  448     12,288     nitro       true         false                x86_64    100 Gigabit          15      0       0                        $109.2              -Not Fetched-            
+u-9tb1.112xlarge   448     9,216      nitro       true         false                x86_64    100 Gigabit          15      0       0                        $81.9               -Not Fetched-            
+u-6tb1.112xlarge   448     6,144      nitro       true         false                x86_64    100 Gigabit          15      0       0                        $54.6               -Not Fetched-            
+u-6tb1.56xlarge    224     6,144      nitro       true         false                x86_64    100 Gigabit          15      0       0                        $46.40391           -Not Fetched-            
+x2iedn.metal       128     4,096      none        true         false                x86_64    100 Gigabit          15      0       0                        $26.676             $8.0028                  
+x2iedn.32xlarge    128     4,096      nitro       true         false                x86_64    100 Gigabit          15      0       0                        $26.676             $8.0028                  
+x1e.32xlarge       128     3,904      xen         true         false                x86_64    25 Gigabit           8       0       0                        $26.688             $8.03461                 
+x2iedn.24xlarge    96      3,072      nitro       true         false                x86_64    75 Gigabit           15      0       0                        $20.007             $13.23032                
+u-3tb1.56xlarge    224     3,072      nitro       true         false                x86_64    50 Gigabit           8       0       0                        $27.3               -Not Fetched-            
+x2idn.metal        128     2,048      none        true         false                x86_64    100 Gigabit          15      0       0                        $13.338             $4.67017
+NOTE: 547 entries were truncated, increase --max-results to see more
+```
+
+**Sort by memory in ascending order using shorthand**
+```
+$ ec2-instance-selector -r us-east-1 -o table-wide --max-results 10 --sort-by memory --sort-direction asc
+Instance Type  VCPUs   Mem (GiB)  Hypervisor  Current Gen  Hibernation Support  CPU Arch      Network Performance  ENIs    GPUs    GPU Mem (GiB)  GPU Info  On-Demand Price/Hr  Spot Price/Hr (30d avg)  
+-------------  -----   ---------  ----------  -----------  -------------------  --------      -------------------  ----    ----    -------------  --------  ------------------  -----------------------  
+t2.nano        1       0.5        xen         true         true                 i386, x86_64  Low to Moderate      2       0       0                        $0.0058             -Not Fetched-            
+t4g.nano       2       0.5        nitro       true         false                arm64         Up to 5 Gigabit      2       0       0                        $0.0042             $0.0013                  
+t3a.nano       2       0.5        nitro       true         true                 x86_64        Up to 5 Gigabit      2       0       0                        $0.0047             $0.00178                 
+t3.nano        2       0.5        nitro       true         true                 x86_64        Up to 5 Gigabit      2       0       0                        $0.0052             $0.0016                  
+t1.micro       1       0.6123     xen         false        false                i386, x86_64  Very Low             2       0       0                        $0.02               $0.00213                 
+t3a.micro      2       1          nitro       true         true                 x86_64        Up to 5 Gigabit      2       0       0                        $0.0094             $0.00332                 
+t3.micro       2       1          nitro       true         true                 x86_64        Up to 5 Gigabit      2       0       0                        $0.0104             $0.0031                  
+t2.micro       1       1          xen         true         true                 i386, x86_64  Low to Moderate      2       0       0                        $0.0116             $0.0035                  
+t4g.micro      2       1          nitro       true         false                arm64         Up to 5 Gigabit      2       0       0                        $0.0084             $0.0025                  
+m1.small       1       1.69922    xen         false        false                i386, x86_64  Low                  2       0       0                        $0.044              $0.00865
+NOTE: 547 entries were truncated, increase --max-results to see more
+```
+
 **All CLI Options**
 
 ```
@@ -153,7 +189,7 @@ $ ec2-instance-selector --help
 ```
 
 ```bash#help
-ec2-instance-selector is a CLI tool to filter EC2 instance types based on resource criteria.
+ec2-instance-selector is a CLI tool to filter EC2 instance types based on resource criteria. 
 Filtering allows you to select all the instance types that match your application requirements.
 Full docs can be found at github.com/aws/amazon-ec2-instance-selector
 
@@ -241,15 +277,17 @@ Suite Flags:
 
 
 Global Flags:
-      --cache-dir string   Directory to save the pricing and instance type caches (default "~/.ec2-instance-selector/")
-      --cache-ttl int      Cache TTLs in hours for pricing and instance type caches. Setting the cache to 0 will turn off caching and cleanup any on-disk caches. (default 168)
-  -h, --help               Help
-      --max-results int    The maximum number of instance types that match your criteria to return (default 20)
-  -o, --output string      Specify the output format (table, table-wide, one-line)
-      --profile string     AWS CLI profile to use for credentials and config
-  -r, --region string      AWS Region to use for API requests (NOTE: if not passed in, uses AWS SDK default precedence)
-  -v, --verbose            Verbose - will print out full instance specs
-      --version            Prints CLI version
+      --cache-dir string        Directory to save the pricing and instance type caches (default "~/.ec2-instance-selector/")
+      --cache-ttl int           Cache TTLs in hours for pricing and instance type caches. Setting the cache to 0 will turn off caching and cleanup any on-disk caches. (default 168)
+  -h, --help                    Help
+      --max-results int         The maximum number of instance types that match your criteria to return (default 20)
+  -o, --output string           Specify the output format (table, table-wide, one-line)
+      --profile string          AWS CLI profile to use for credentials and config
+  -r, --region string           AWS Region to use for API requests (NOTE: if not passed in, uses AWS SDK default precedence)
+      --sort-by string          Specify the field to sort by. Any quantity flag present in this CLI (vcpus, memory, gpu-memory-total, network-interfaces, spot-price, on-demand-price, instance-storage, ebs-optimized-baseline-bandwidth, ebs-optimized-baseline-throughput, ebs-optimized-baseline-iops, gpus, inference-accelerators) or a JSON path to the appropriate field in the instancetype.Details struct is acceptable. (default "$.InstanceType")
+      --sort-direction string   Specify the direction to sort in (ascending, asc, descending, desc) (default "ascending")
+  -v, --verbose                 Verbose - will print out full instance specs
+      --version                 Prints CLI version
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ t3a.medium     2       4          nitro       true         true                 
 
 **Sort by memory in descending order using JSON path**
 ```
-$ ec2-instance-selector -r us-east-1 -o table-wide --max-results 10 --sort-by $.MemoryInfo.SizeInMiB --sort-direction desc
+$ ec2-instance-selector -r us-east-1 -o table-wide --max-results 10 --sort-by .MemoryInfo.SizeInMiB --sort-direction desc
 Instance Type      VCPUs   Mem (GiB)  Hypervisor  Current Gen  Hibernation Support  CPU Arch  Network Performance  ENIs    GPUs    GPU Mem (GiB)  GPU Info  On-Demand Price/Hr  Spot Price/Hr (30d avg)  
 -------------      -----   ---------  ----------  -----------  -------------------  --------  -------------------  ----    ----    -------------  --------  ------------------  -----------------------  
 u-12tb1.112xlarge  448     12,288     nitro       true         false                x86_64    100 Gigabit          15      0       0                        $109.2              -Not Fetched-            

--- a/README.md
+++ b/README.md
@@ -146,24 +146,6 @@ t3.medium      2       4          nitro       true         true                 
 t3a.medium     2       4          nitro       true         true                 x86_64        Up to 5 Gigabit      3       0       0                        $0.0376             $0.01431
 ```
 
-**Sort by memory in descending order using JSON path**
-```
-$ ec2-instance-selector -r us-east-1 -o table-wide --max-results 10 --sort-by .MemoryInfo.SizeInMiB --sort-direction desc
-Instance Type      VCPUs   Mem (GiB)  Hypervisor  Current Gen  Hibernation Support  CPU Arch  Network Performance  ENIs    GPUs    GPU Mem (GiB)  GPU Info  On-Demand Price/Hr  Spot Price/Hr (30d avg)  
--------------      -----   ---------  ----------  -----------  -------------------  --------  -------------------  ----    ----    -------------  --------  ------------------  -----------------------  
-u-12tb1.112xlarge  448     12,288     nitro       true         false                x86_64    100 Gigabit          15      0       0                        $109.2              -Not Fetched-            
-u-9tb1.112xlarge   448     9,216      nitro       true         false                x86_64    100 Gigabit          15      0       0                        $81.9               -Not Fetched-            
-u-6tb1.112xlarge   448     6,144      nitro       true         false                x86_64    100 Gigabit          15      0       0                        $54.6               -Not Fetched-            
-u-6tb1.56xlarge    224     6,144      nitro       true         false                x86_64    100 Gigabit          15      0       0                        $46.40391           -Not Fetched-            
-x2iedn.metal       128     4,096      none        true         false                x86_64    100 Gigabit          15      0       0                        $26.676             $8.0028                  
-x2iedn.32xlarge    128     4,096      nitro       true         false                x86_64    100 Gigabit          15      0       0                        $26.676             $8.0028                  
-x1e.32xlarge       128     3,904      xen         true         false                x86_64    25 Gigabit           8       0       0                        $26.688             $8.03461                 
-x2iedn.24xlarge    96      3,072      nitro       true         false                x86_64    75 Gigabit           15      0       0                        $20.007             $13.23032                
-u-3tb1.56xlarge    224     3,072      nitro       true         false                x86_64    50 Gigabit           8       0       0                        $27.3               -Not Fetched-            
-x2idn.metal        128     2,048      none        true         false                x86_64    100 Gigabit          15      0       0                        $13.338             $4.67017
-NOTE: 547 entries were truncated, increase --max-results to see more
-```
-
 **Sort by memory in ascending order using shorthand**
 ```
 $ ec2-instance-selector -r us-east-1 -o table-wide --max-results 10 --sort-by memory --sort-direction asc
@@ -181,6 +163,122 @@ t4g.micro      2       1          nitro       true         false                
 m1.small       1       1.69922    xen         false        false                i386, x86_64  Low                  2       0       0                        $0.044              $0.00865
 NOTE: 547 entries were truncated, increase --max-results to see more
 ```
+Available shorthand flags: vcpus, memory, gpu-memory-total, network-interfaces, spot-price, on-demand-price, instance-storage, ebs-optimized-baseline-bandwidth, ebs-optimized-baseline-throughput, ebs-optimized-baseline-iops, gpus, inference-accelerators
+
+**Sort by memory in descending order using JSON path**
+```
+$ ec2-instance-selector -r us-east-1 -o table-wide --max-results 10 --sort-by .MemoryInfo.SizeInMiB --sort-direction desc
+Instance Type      VCPUs   Mem (GiB)  Hypervisor  Current Gen  Hibernation Support  CPU Arch  Network Performance  ENIs    GPUs    GPU Mem (GiB)  GPU Info  On-Demand Price/Hr  Spot Price/Hr (30d avg)  
+-------------      -----   ---------  ----------  -----------  -------------------  --------  -------------------  ----    ----    -------------  --------  ------------------  -----------------------  
+u-12tb1.112xlarge  448     12,288     nitro       true         false                x86_64    100 Gigabit          15      0       0                        $109.2              -Not Fetched-            
+u-9tb1.112xlarge   448     9,216      nitro       true         false                x86_64    100 Gigabit          15      0       0                        $81.9               -Not Fetched-            
+u-6tb1.112xlarge   448     6,144      nitro       true         false                x86_64    100 Gigabit          15      0       0                        $54.6               -Not Fetched-            
+u-6tb1.56xlarge    224     6,144      nitro       true         false                x86_64    100 Gigabit          15      0       0                        $46.40391           -Not Fetched-            
+x2iedn.metal       128     4,096      none        true         false                x86_64    100 Gigabit          15      0       0                        $26.676             $8.0028                  
+x2iedn.32xlarge    128     4,096      nitro       true         false                x86_64    100 Gigabit          15      0       0                        $26.676             $8.0028                  
+x1e.32xlarge       128     3,904      xen         true         false                x86_64    25 Gigabit           8       0       0                        $26.688             $8.03461                 
+x2iedn.24xlarge    96      3,072      nitro       true         false                x86_64    75 Gigabit           15      0       0                        $20.007             $13.23032                
+u-3tb1.56xlarge    224     3,072      nitro       true         false                x86_64    50 Gigabit           8       0       0                        $27.3               -Not Fetched-            
+x2idn.metal        128     2,048      none        true         false                x86_64    100 Gigabit          15      0       0                        $13.338             $4.67017
+NOTE: 547 entries were truncated, increase --max-results to see more
+```
+JSON path must point to a field in the [instancetype.Details struct](https://github.com/aws/amazon-ec2-instance-selector/blob/5bffbf2750ee09f5f1308bdc8d4b635a2c6e2721/pkg/instancetypes/instancetypes.go#L37).
+
+**Example output of instance type object using Verbose output**
+```
+$ ec2-instance-selector --max-results 1 -v
+[
+    {
+        "AutoRecoverySupported": true,
+        "BareMetal": false,
+        "BurstablePerformanceSupported": false,
+        "CurrentGeneration": false,
+        "DedicatedHostsSupported": true,
+        "EbsInfo": {
+            "EbsOptimizedInfo": {
+                "BaselineBandwidthInMbps": 1750,
+                "BaselineIops": 10000,
+                "BaselineThroughputInMBps": 218.75,
+                "MaximumBandwidthInMbps": 3500,
+                "MaximumIops": 20000,
+                "MaximumThroughputInMBps": 437.5
+            },
+            "EbsOptimizedSupport": "default",
+            "EncryptionSupport": "supported",
+            "NvmeSupport": "required"
+        },
+        "FpgaInfo": null,
+        "FreeTierEligible": false,
+        "GpuInfo": null,
+        "HibernationSupported": false,
+        "Hypervisor": "nitro",
+        "InferenceAcceleratorInfo": null,
+        "InstanceStorageInfo": null,
+        "InstanceStorageSupported": false,
+        "InstanceType": "a1.2xlarge",
+        "MemoryInfo": {
+            "SizeInMiB": 16384
+        },
+        "NetworkInfo": {
+            "DefaultNetworkCardIndex": 0,
+            "EfaInfo": null,
+            "EfaSupported": false,
+            "EnaSupport": "required",
+            "EncryptionInTransitSupported": false,
+            "Ipv4AddressesPerInterface": 15,
+            "Ipv6AddressesPerInterface": 15,
+            "Ipv6Supported": true,
+            "MaximumNetworkCards": 1,
+            "MaximumNetworkInterfaces": 4,
+            "NetworkCards": [
+                {
+                    "MaximumNetworkInterfaces": 4,
+                    "NetworkCardIndex": 0,
+                    "NetworkPerformance": "Up to 10 Gigabit"
+                }
+            ],
+            "NetworkPerformance": "Up to 10 Gigabit"
+        },
+        "PlacementGroupInfo": {
+            "SupportedStrategies": [
+                "cluster",
+                "partition",
+                "spread"
+            ]
+        },
+        "ProcessorInfo": {
+            "SupportedArchitectures": [
+                "arm64"
+            ],
+            "SustainedClockSpeedInGhz": 2.3
+        },
+        "SupportedBootModes": [
+            "uefi"
+        ],
+        "SupportedRootDeviceTypes": [
+            "ebs"
+        ],
+        "SupportedUsageClasses": [
+            "on-demand",
+            "spot"
+        ],
+        "SupportedVirtualizationTypes": [
+            "hvm"
+        ],
+        "VCpuInfo": {
+            "DefaultCores": 8,
+            "DefaultThreadsPerCore": 1,
+            "DefaultVCpus": 8,
+            "ValidCores": null,
+            "ValidThreadsPerCore": null
+        },
+        "OndemandPricePerHour": 0.204,
+        "SpotPrice": 0.03939999999999999
+    }
+]
+NOTE: 497 entries were truncated, increase --max-results to see more
+```
+NOTE: Use this JSON format as reference when finding JSON paths for sorting
 
 **All CLI Options**
 
@@ -284,7 +382,7 @@ Global Flags:
   -o, --output string           Specify the output format (table, table-wide, one-line)
       --profile string          AWS CLI profile to use for credentials and config
   -r, --region string           AWS Region to use for API requests (NOTE: if not passed in, uses AWS SDK default precedence)
-      --sort-by string          Specify the field to sort by. Any quantity flag present in this CLI (vcpus, memory, gpu-memory-total, network-interfaces, spot-price, on-demand-price, instance-storage, ebs-optimized-baseline-bandwidth, ebs-optimized-baseline-throughput, ebs-optimized-baseline-iops, gpus, inference-accelerators) or a JSON path to the appropriate field in the instancetype.Details struct is acceptable. (default "$.InstanceType")
+      --sort-by string          Specify the field to sort by. Quantity flags present in this CLI (memory, gpus, etc.) or a JSON path to the appropriate instance type field (Ex: ".MemoryInfo.SizeInMiB") is acceptable. (default ".InstanceType")
       --sort-direction string   Specify the direction to sort in (ascending, asc, descending, desc) (default "ascending")
   -v, --verbose                 Verbose - will print out full instance specs
       --version                 Prints CLI version

--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -854,3 +854,30 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+------
+
+** github.com/oliveagle/jsonpath; version v0.0.0-20180606110733-2e52cf6e6852 --
+https://github.com/oliveagle/jsonpath
+
+The MIT License (MIT)
+
+Copyright (c) 2015 oliver
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -464,18 +464,11 @@ Full docs can be found at github.com/aws/amazon-` + binName
 			os.Exit(1)
 		}
 
-		// sort instance types
-		sorter, err := sorter.NewSorter(instanceTypeDetails, *sortField, *sortDirection)
+		instanceTypeDetails, err = sorter.Sort(instanceTypeDetails, *sortField, *sortDirection)
 		if err != nil {
-			fmt.Printf("An error occurred when preparing to sort instance types: %v", err)
+			fmt.Printf("Sorting error: %v", err)
 			os.Exit(1)
 		}
-		err = sorter.Sort()
-		if err != nil {
-			fmt.Printf("An error occurred when sorting instance types: %v", err)
-			os.Exit(1)
-		}
-		instanceTypeDetails = sorter.InstanceTypes()
 
 		// truncate instance types based on user passed in maxResults
 		instanceTypeDetails, itemsTruncated = truncateResults(prevMaxResults, instanceTypeDetails)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -132,17 +132,17 @@ const (
 	odPrice   = "on-demand-price"
 
 	// JSON field paths
-	instanceNamePath                   = "$.InstanceType"
-	vcpuPath                           = "$.VCpuInfo.DefaultVCpus"
-	memoryPath                         = "$.MemoryInfo.SizeInMiB"
-	gpuMemoryTotalPath                 = "$.GpuInfo.TotalGpuMemoryInMiB"
-	networkInterfacesPath              = "$.NetworkInfo.MaximumNetworkInterfaces"
-	spotPricePath                      = "$.SpotPrice"
-	odPricePath                        = "$.OndemandPricePerHour"
-	instanceStoragePath                = "$.InstanceStorageInfo.TotalSizeInGB"
-	ebsOptimizedBaselineBandwidthPath  = "$.EbsInfo.EbsOptimizedInfo.BaselineBandwidthInMbps"
-	ebsOptimizedBaselineThroughputPath = "$.EbsInfo.EbsOptimizedInfo.BaselineThroughputInMBps"
-	ebsOptimizedBaselineIOPSPath       = "$.EbsInfo.EbsOptimizedInfo.BaselineIops"
+	instanceNamePath                   = ".InstanceType"
+	vcpuPath                           = ".VCpuInfo.DefaultVCpus"
+	memoryPath                         = ".MemoryInfo.SizeInMiB"
+	gpuMemoryTotalPath                 = ".GpuInfo.TotalGpuMemoryInMiB"
+	networkInterfacesPath              = ".NetworkInfo.MaximumNetworkInterfaces"
+	spotPricePath                      = ".SpotPrice"
+	odPricePath                        = ".OndemandPricePerHour"
+	instanceStoragePath                = ".InstanceStorageInfo.TotalSizeInGB"
+	ebsOptimizedBaselineBandwidthPath  = ".EbsInfo.EbsOptimizedInfo.BaselineBandwidthInMbps"
+	ebsOptimizedBaselineThroughputPath = ".EbsInfo.EbsOptimizedInfo.BaselineThroughputInMBps"
+	ebsOptimizedBaselineIOPSPath       = ".EbsInfo.EbsOptimizedInfo.BaselineIops"
 )
 
 var (

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -278,16 +278,7 @@ Full docs can be found at github.com/aws/amazon-` + binName
 	cli.ConfigBoolFlag(help, cli.StringMe("h"), nil, "Help")
 	cli.ConfigBoolFlag(version, nil, nil, "Prints CLI version")
 	cli.ConfigStringOptionsFlag(sortDirection, nil, cli.StringMe(sortAscending), fmt.Sprintf("Specify the direction to sort in (%s)", strings.Join(cliSortDirections, ", ")), cliSortDirections)
-	cli.ConfigStringFlag(
-		sortBy,
-		nil,
-		cli.StringMe(instanceNamePath),
-		fmt.Sprintf(
-			"Specify the field to sort by. Any quantity flag present in this CLI (%s) or a JSON path to the appropriate field in the instancetype.Details struct is acceptable.",
-			strings.Join(sortingShorthandFlags, ", "),
-		),
-		nil,
-	)
+	cli.ConfigStringFlag(sortBy, nil, cli.StringMe(instanceNamePath), "Specify the field to sort by. Quantity flags present in this CLI (memory, gpus, etc.) or a JSON path to the appropriate instance type field (Ex: \".MemoryInfo.SizeInMiB\") is acceptable.", nil)
 
 	// Parses the user input with the registered flags and runs type specific validation on the user input
 	flags, err := cli.ParseAndValidateFlags()

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -434,8 +434,7 @@ Full docs can be found at github.com/aws/amazon-` + binName
 	}
 
 	// determine if user used a shorthand for sorting flag
-	sortFieldShorthandPath, ok := sortingKeysMap[*sortField]
-	if ok {
+	if sortFieldShorthandPath, ok := sortingKeysMap[*sortField]; ok {
 		sortField = &sortFieldShorthandPath
 	}
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -25,8 +25,10 @@ import (
 
 	commandline "github.com/aws/amazon-ec2-instance-selector/v2/pkg/cli"
 	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/env"
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/instancetypes"
 	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector"
 	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector/outputs"
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/sorter"
 	"github.com/aws/aws-sdk-go/aws/session"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
@@ -103,15 +105,30 @@ const (
 
 // Configuration Flag Constants
 const (
-	maxResults = "max-results"
-	profile    = "profile"
-	help       = "help"
-	verbose    = "verbose"
-	version    = "version"
-	region     = "region"
-	output     = "output"
-	cacheTTL   = "cache-ttl"
-	cacheDir   = "cache-dir"
+	maxResults    = "max-results"
+	profile       = "profile"
+	help          = "help"
+	verbose       = "verbose"
+	version       = "version"
+	region        = "region"
+	output        = "output"
+	cacheTTL      = "cache-ttl"
+	cacheDir      = "cache-dir"
+	sortDirection = "sort-direction"
+	sortBy        = "sort-by"
+)
+
+// Sorting Constants
+const (
+	// Direction
+
+	sortAscending  = "ascending"
+	sortAsc        = "asc"
+	sortDescending = "descending"
+	sortDesc       = "desc"
+
+	// JSON field paths
+	instanceNamePath = "$.InstanceType"
 )
 
 var (
@@ -141,6 +158,15 @@ Full docs can be found at github.com/aws/amazon-` + binName
 		oneLine,
 	}
 	resultsOutputFn := outputs.SimpleInstanceTypeOutput
+
+	cliSortDirections := []string{
+		sortAscending,
+		sortAsc,
+		sortDescending,
+		sortDesc,
+	}
+
+	// TODO: map all cli flags to json paths for sorting
 
 	// Registers flags with specific input types from the cli pkg
 	// Filter Flags - These will be grouped at the top of the help flags
@@ -206,6 +232,8 @@ Full docs can be found at github.com/aws/amazon-` + binName
 	cli.ConfigBoolFlag(verbose, cli.StringMe("v"), nil, "Verbose - will print out full instance specs")
 	cli.ConfigBoolFlag(help, cli.StringMe("h"), nil, "Help")
 	cli.ConfigBoolFlag(version, nil, nil, "Prints CLI version")
+	cli.ConfigStringOptionsFlag(sortDirection, nil, cli.StringMe(sortAscending), fmt.Sprintf("Specify the direction to sort in (%s)", strings.Join(cliSortDirections, ", ")), cliSortDirections)
+	cli.ConfigStringFlag(sortBy, nil, cli.StringMe(instanceNamePath), "Specify the field to sort by. Any quantity flag present in this CLI or a JSON path to the appropriate instancetype.Details struct is acceptable.", nil)
 
 	// Parses the user input with the registered flags and runs type specific validation on the user input
 	flags, err := cli.ParseAndValidateFlags()
@@ -237,6 +265,9 @@ Full docs can be found at github.com/aws/amazon-` + binName
 		}
 	}
 	registerShutdown(shutdown)
+
+	sortField := cli.StringMe(flags[sortBy])
+	lowercaseSortField := strings.ToLower(*sortField)
 	outputFlag := cli.StringMe(flags[output])
 	if outputFlag != nil && *outputFlag == tableWideOutput {
 		// If output type is `table-wide`, simply print both prices for better comparison,
@@ -245,18 +276,37 @@ Full docs can be found at github.com/aws/amazon-` + binName
 		if err := hydrateCaches(*instanceSelector); err != nil {
 			log.Printf("%v", err)
 		}
-	} else if flags[pricePerHour] != nil {
+	} else {
 		// Else, if price filters are applied, only hydrate the respective cache as we don't have to print the prices
-		if flags[usageClass] == nil || *cli.StringMe(flags[usageClass]) == "on-demand" {
-			if instanceSelector.EC2Pricing.OnDemandCacheCount() == 0 {
-				if err := instanceSelector.EC2Pricing.RefreshOnDemandCache(); err != nil {
-					log.Printf("There was a problem refreshing the on-demand pricing cache: %v", err)
+		if flags[pricePerHour] != nil {
+			if flags[usageClass] == nil || *cli.StringMe(flags[usageClass]) == "on-demand" {
+				if instanceSelector.EC2Pricing.OnDemandCacheCount() == 0 {
+					if err := instanceSelector.EC2Pricing.RefreshOnDemandCache(); err != nil {
+						log.Printf("There was a problem refreshing the on-demand pricing cache: %v", err)
+					}
+				}
+			} else {
+				if instanceSelector.EC2Pricing.SpotCacheCount() == 0 {
+					if err := instanceSelector.EC2Pricing.RefreshSpotCache(spotPricingDaysBack); err != nil {
+						log.Printf("There was a problem refreshing the spot pricing cache: %v", err)
+					}
 				}
 			}
-		} else {
-			if instanceSelector.EC2Pricing.SpotCacheCount() == 0 {
-				if err := instanceSelector.EC2Pricing.RefreshSpotCache(spotPricingDaysBack); err != nil {
-					log.Printf("There was a problem refreshing the spot pricing cache: %v", err)
+		}
+
+		// refresh appropriate caches if sorting by either spot or on demand pricing
+		if strings.Contains(lowercaseSortField, "price") {
+			if strings.Contains(lowercaseSortField, "spot") {
+				if instanceSelector.EC2Pricing.SpotCacheCount() == 0 {
+					if err := instanceSelector.EC2Pricing.RefreshSpotCache(spotPricingDaysBack); err != nil {
+						log.Printf("There was a problem refreshing the spot pricing cache: %v", err)
+					}
+				}
+			} else {
+				if instanceSelector.EC2Pricing.OnDemandCacheCount() == 0 {
+					if err := instanceSelector.EC2Pricing.RefreshOnDemandCache(); err != nil {
+						log.Printf("There was a problem refreshing the on-demand pricing cache: %v", err)
+					}
 				}
 			}
 		}
@@ -339,15 +389,55 @@ Full docs can be found at github.com/aws/amazon-` + binName
 	}
 
 	outputFn := getOutputFn(outputFlag, selector.InstanceTypesOutputFn(resultsOutputFn))
+	var instanceTypes []string
+	var itemsTruncated int
 
-	instanceTypes, itemsTruncated, err := instanceSelector.FilterWithOutput(filters, outputFn)
-	if err != nil {
-		fmt.Printf("An error occurred when filtering instance types: %v", err)
-		os.Exit(1)
-	}
-	if len(instanceTypes) == 0 {
-		log.Println("The criteria was too narrow and returned no valid instance types. Consider broadening your criteria so that more instance types are returned.")
-		os.Exit(1)
+	sortDirection := cli.StringMe(flags[sortDirection])
+	if *sortField == instanceNamePath && (*sortDirection == sortAscending || *sortDirection == sortAsc) {
+		// filter already sorts in ascending order by name
+		instanceTypes, itemsTruncated, err = instanceSelector.FilterWithOutput(filters, outputFn)
+		if err != nil {
+			fmt.Printf("An error occurred when filtering instance types: %v", err)
+			os.Exit(1)
+		}
+		if len(instanceTypes) == 0 {
+			log.Println("The criteria was too narrow and returned no valid instance types. Consider broadening your criteria so that more instance types are returned.")
+			os.Exit(1)
+		}
+	} else {
+		// have to sort before truncation
+
+		// fetch instance types without truncating results
+		prevMaxResults := filters.MaxResults
+		filters.MaxResults = nil
+		instanceTypeDetails, err := instanceSelector.FilterVerbose(filters)
+		if err != nil {
+			fmt.Printf("An error occurred when filtering instance types: %v", err)
+			os.Exit(1)
+		}
+
+		// sort instance types
+		sorter, err := sorter.NewSorter(instanceTypeDetails, *sortField, *sortDirection)
+		if err != nil {
+			fmt.Printf("An error occurred when preparing to sort instance types: %v", err)
+			os.Exit(1)
+		}
+		err = sorter.Sort()
+		if err != nil {
+			fmt.Printf("An error occurred when sorting instance types: %v", err)
+			os.Exit(1)
+		}
+		instanceTypeDetails = sorter.InstanceTypes()
+
+		// truncate instance types based on user passed in maxResults
+		instanceTypeDetails, itemsTruncated = truncateResults(prevMaxResults, instanceTypeDetails)
+		if len(instanceTypeDetails) == 0 {
+			log.Println("The criteria was too narrow and returned no valid instance types. Consider broadening your criteria so that more instance types are returned.")
+			os.Exit(1)
+		}
+
+		// format instance types for output
+		instanceTypes = outputFn(instanceTypeDetails)
 	}
 
 	for _, instanceType := range instanceTypes {
@@ -486,4 +576,15 @@ func registerShutdown(shutdown func()) {
 		<-sigs
 		shutdown()
 	}()
+}
+
+func truncateResults(maxResults *int, instanceTypeInfoSlice []*instancetypes.Details) ([]*instancetypes.Details, int) {
+	if maxResults == nil {
+		return instanceTypeInfoSlice, 0
+	}
+	upperIndex := *maxResults
+	if *maxResults > len(instanceTypeInfoSlice) {
+		upperIndex = len(instanceTypeInfoSlice)
+	}
+	return instanceTypeInfoSlice[0:upperIndex], len(instanceTypeInfoSlice) - upperIndex
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -205,7 +205,7 @@ Full docs can be found at github.com/aws/amazon-` + binName
 		instanceStoragePath,
 		ebsOptimizedBaselineBandwidthPath,
 		ebsOptimizedBaselineThroughputPath,
-		ebsOptimizedBaselineIOPS,
+		ebsOptimizedBaselineIOPSPath,
 		gpus,
 		inferenceAccelerators,
 	}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -180,38 +180,21 @@ Full docs can be found at github.com/aws/amazon-` + binName
 		sortDesc,
 	}
 
-	sortingShorthandFlags := []string{
-		vcpus,
-		memory,
-		gpuMemoryTotal,
-		networkInterfaces,
-		spotPrice,
-		odPrice,
-		instanceStorage,
-		ebsOptimizedBaselineBandwidth,
-		ebsOptimizedBaselineThroughput,
-		ebsOptimizedBaselineIOPS,
-		gpus,
-		inferenceAccelerators,
-	}
-
-	sortingShorthandPaths := []string{
-		vcpuPath,
-		memoryPath,
-		gpuMemoryTotalPath,
-		networkInterfacesPath,
-		spotPricePath,
-		odPricePath,
-		instanceStoragePath,
-		ebsOptimizedBaselineBandwidthPath,
-		ebsOptimizedBaselineThroughputPath,
-		ebsOptimizedBaselineIOPSPath,
-		gpus,
-		inferenceAccelerators,
-	}
-
 	// map quantity cli flags to json paths for easier cli sorting
-	sortingKeysMap := mapQuantityFlagsToPath(&sortingShorthandFlags, &sortingShorthandPaths)
+	sortingKeysMap := map[string]string{
+		vcpus:                          vcpuPath,
+		memory:                         memoryPath,
+		gpuMemoryTotal:                 gpuMemoryTotalPath,
+		networkInterfaces:              networkInterfacesPath,
+		spotPrice:                      spotPricePath,
+		odPrice:                        odPricePath,
+		instanceStorage:                instanceStoragePath,
+		ebsOptimizedBaselineBandwidth:  ebsOptimizedBaselineBandwidthPath,
+		ebsOptimizedBaselineThroughput: ebsOptimizedBaselineThroughputPath,
+		ebsOptimizedBaselineIOPS:       ebsOptimizedBaselineIOPSPath,
+		gpus:                           gpus,
+		inferenceAccelerators:          inferenceAccelerators,
+	}
 
 	// Registers flags with specific input types from the cli pkg
 	// Filter Flags - These will be grouped at the top of the help flags
@@ -628,13 +611,4 @@ func truncateResults(maxResults *int, instanceTypeInfoSlice []*instancetypes.Det
 		upperIndex = len(instanceTypeInfoSlice)
 	}
 	return instanceTypeInfoSlice[0:upperIndex], len(instanceTypeInfoSlice) - upperIndex
-}
-
-func mapQuantityFlagsToPath(flags *[]string, paths *[]string) map[string]string {
-	sortingFlagKeys := make(map[string]string)
-	for i := range *flags {
-		sortingFlagKeys[(*flags)[i]] = (*paths)[i]
-	}
-
-	return sortingFlagKeys
 }

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 require (
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/oliveagle/jsonpath v0.0.0-20180606110733-2e52cf6e6852 // indirect
 	github.com/smartystreets/goconvey v1.6.4 // indirect
 	go.uber.org/atomic v1.4.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -73,6 +73,8 @@ github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrk
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
+github.com/oliveagle/jsonpath v0.0.0-20180606110733-2e52cf6e6852 h1:Yl0tPBa8QPjGmesFh1D0rDy+q1Twx6FyU7VWHi8wZbI=
+github.com/oliveagle/jsonpath v0.0.0-20180606110733-2e52cf6e6852/go.mod h1:eqOVx5Vwu4gd2mmMZvVZsgIqNSaW3xxRThUJ0k/TPk4=
 github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaRUnok+kx1WdO15EQc=
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=

--- a/pkg/selector/emr.go
+++ b/pkg/selector/emr.go
@@ -56,10 +56,18 @@ func (e EMR) getEMRInstanceTypes(version semver.Version) ([]string, error) {
 	instanceTypes := []string{}
 
 	for _, instanceType := range e.getAllEMRInstanceTypes() {
-		if semver.MustParseRange(">=5.25.0")(version) {
+		if semver.MustParseRange(">=5.33.0")(version) {
+			instanceTypes = append(instanceTypes, instanceType)
+		} else if semver.MustParseRange(">=5.25.0 <5.33.0")(version) {
+			if e.isOnlyEMR_5_33_0_plus(instanceType) {
+				continue
+			}
 			instanceTypes = append(instanceTypes, instanceType)
 		} else if semver.MustParseRange(">=5.20.0 <5.25.0")(version) {
 			if e.isOnlyEMR_5_25_0_plus(instanceType) {
+				continue
+			}
+			if e.isOnlyEMR_5_33_0_plus(instanceType) {
 				continue
 			}
 			instanceTypes = append(instanceTypes, instanceType)
@@ -73,12 +81,18 @@ func (e EMR) getEMRInstanceTypes(version semver.Version) ([]string, error) {
 			if e.isOnlyEMR_5_25_0_plus(instanceType) {
 				continue
 			}
+			if e.isOnlyEMR_5_33_0_plus(instanceType) {
+				continue
+			}
 			instanceTypes = append(instanceTypes, instanceType)
 		} else if semver.MustParseRange(">=5.13.0 <5.15.0")(version) {
 			if e.isOnlyEMR_5_20_0_plus(instanceType) {
 				continue
 			}
 			if e.isOnlyEMR_5_25_0_plus(instanceType) {
+				continue
+			}
+			if e.isOnlyEMR_5_33_0_plus(instanceType) {
 				continue
 			}
 			instanceTypes = append(instanceTypes, instanceType)
@@ -92,6 +106,9 @@ func (e EMR) getEMRInstanceTypes(version semver.Version) ([]string, error) {
 			if e.isOnlyEMR_5_25_0_plus(instanceType) {
 				continue
 			}
+			if e.isOnlyEMR_5_33_0_plus(instanceType) {
+				continue
+			}
 			instanceTypes = append(instanceTypes, instanceType)
 		} else {
 			if e.isEMR_5_13_0_plus(instanceType) {
@@ -101,6 +118,9 @@ func (e EMR) getEMRInstanceTypes(version semver.Version) ([]string, error) {
 				continue
 			}
 			if e.isOnlyEMR_5_25_0_plus(instanceType) {
+				continue
+			}
+			if e.isOnlyEMR_5_33_0_plus(instanceType) {
 				continue
 			}
 			if strings.HasPrefix(instanceType, "i3") {
@@ -155,6 +175,21 @@ func (EMR) isOnlyEMR_5_25_0_plus(instanceType string) bool {
 	return false
 }
 
+func (EMR) isOnlyEMR_5_33_0_plus(instanceType string) bool {
+	prefixes := []string{
+		"m5zn.",
+		"m6gd",
+		"r5b",
+		"r6gd",
+	}
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(instanceType, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
 func (EMR) getAllEMRInstanceTypes() []string {
 	return []string{
 		"c1.medium",
@@ -177,11 +212,17 @@ func (EMR) getAllEMRInstanceTypes() []string {
 		"c5.xlarge",
 		"c5a.12xlarge",
 		"c5a.16xlarge",
-		"c5a.24xlarge",
 		"c5a.2xlarge",
 		"c5a.4xlarge",
 		"c5a.8xlarge",
 		"c5a.xlarge",
+		"c5ad.12xlarge",
+		"c5ad.16xlarge",
+		"c5ad.24xlarge",
+		"c5ad.2xlarge",
+		"c5ad.4xlarge",
+		"c5ad.8xlarge",
+		"c5ad.xlarge",
 		"c5d.12xlarge",
 		"c5d.18xlarge",
 		"c5d.24xlarge",
@@ -200,11 +241,34 @@ func (EMR) getAllEMRInstanceTypes() []string {
 		"c6g.4xlarge",
 		"c6g.8xlarge",
 		"c6g.xlarge",
+		"c6gd.12xlarge",
+		"c6gd.16xlarge",
+		"c6gd.2xlarge",
+		"c6gd.4xlarge",
+		"c6gd.8xlarge",
+		"c6gd.xlarge",
+		"c6gn.12xlarge",
+		"c6gn.16xlarge",
+		"c6gn.2xlarge",
+		"c6gn.4xlarge",
+		"c6gn.8xlarge",
+		"c6gn.xlarge",
 		"cc2.8xlarge",
+		"cr1.8xlarge",
 		"d2.2xlarge",
 		"d2.4xlarge",
 		"d2.8xlarge",
 		"d2.xlarge",
+		"d3.2xlarge",
+		"d3.4xlarge",
+		"d3.8xlarge",
+		"d3.xlarge",
+		"d3en.2xlarge",
+		"d3en.4xlarge",
+		"d3en.6xlarge",
+		"d3en.8xlarge",
+		"d3en.12xlarge",
+		"d3en.xlarge",
 		"g2.2xlarge",
 		"g3.16xlarge",
 		"g3.4xlarge",
@@ -220,6 +284,7 @@ func (EMR) getAllEMRInstanceTypes() []string {
 		"h1.2xlarge",
 		"h1.4xlarge",
 		"h1.8xlarge",
+		"hs1.8xlarge",
 		"i2.2xlarge",
 		"i2.4xlarge",
 		"i2.8xlarge",
@@ -256,7 +321,6 @@ func (EMR) getAllEMRInstanceTypes() []string {
 		"m5.2xlarge",
 		"m5.4xlarge",
 		"m5.8xlarge",
-		"m5.metal",
 		"m5.xlarge",
 		"m5a.12xlarge",
 		"m5a.16xlarge",
@@ -265,42 +329,30 @@ func (EMR) getAllEMRInstanceTypes() []string {
 		"m5a.4xlarge",
 		"m5a.8xlarge",
 		"m5a.xlarge",
-		"m5ad.12xlarge",
-		"m5ad.16xlarge",
-		"m5ad.24xlarge",
-		"m5ad.2xlarge",
-		"m5ad.4xlarge",
-		"m5ad.8xlarge",
-		"m5ad.xlarge",
 		"m5d.12xlarge",
 		"m5d.16xlarge",
 		"m5d.24xlarge",
 		"m5d.2xlarge",
 		"m5d.4xlarge",
 		"m5d.8xlarge",
-		"m5d.metal",
 		"m5d.xlarge",
-		"m5dn.12xlarge",
-		"m5dn.16xlarge",
-		"m5dn.24xlarge",
-		"m5dn.2xlarge",
-		"m5dn.4xlarge",
-		"m5dn.8xlarge",
-		"m5dn.xlarge",
-		"m5n.12xlarge",
-		"m5n.16xlarge",
-		"m5n.24xlarge",
-		"m5n.2xlarge",
-		"m5n.4xlarge",
-		"m5n.8xlarge",
-		"m5n.xlarge",
+		"m5zn.12xlarge",
+		"m5zn.2xlarge",
+		"m5zn.3xlarge",
+		"m5zn.6xlarge",
+		"m5zn.xlarge",
 		"m6g.12xlarge",
 		"m6g.16xlarge",
 		"m6g.2xlarge",
 		"m6g.4xlarge",
 		"m6g.8xlarge",
 		"m6g.xlarge",
-		"mac1.metal",
+		"m6gd.12xlarge",
+		"m6gd.16xlarge",
+		"m6gd.2xlarge",
+		"m6gd.4xlarge",
+		"m6gd.8xlarge",
+		"m6gd.xlarge",
 		"p2.16xlarge",
 		"p2.8xlarge",
 		"p2.xlarge",
@@ -323,7 +375,6 @@ func (EMR) getAllEMRInstanceTypes() []string {
 		"r5.2xlarge",
 		"r5.4xlarge",
 		"r5.8xlarge",
-		"r5.metal",
 		"r5.xlarge",
 		"r5a.12xlarge",
 		"r5a.16xlarge",
@@ -332,27 +383,39 @@ func (EMR) getAllEMRInstanceTypes() []string {
 		"r5a.4xlarge",
 		"r5a.8xlarge",
 		"r5a.xlarge",
+		"r5b.12xlarge",
+		"r5b.16xlarge",
+		"r5b.24xlarge",
+		"r5b.2xlarge",
+		"r5b.4xlarge",
+		"r5b.8xlarge",
+		"r5b.xlarge",
 		"r5d.12xlarge",
 		"r5d.16xlarge",
 		"r5d.24xlarge",
 		"r5d.2xlarge",
 		"r5d.4xlarge",
 		"r5d.8xlarge",
-		"r5d.metal",
 		"r5d.xlarge",
-		"r5n.12xlarge",
-		"r5n.16xlarge",
-		"r5n.24xlarge",
-		"r5n.2xlarge",
-		"r5n.4xlarge",
-		"r5n.8xlarge",
-		"r5n.xlarge",
+		"r5dn.12xlarge",
+		"r5dn.16xlarge",
+		"r5dn.24xlarge",
+		"r5dn.2xlarge",
+		"r5dn.4xlarge",
+		"r5dn.8xlarge",
+		"r5dn.xlarge",
 		"r6g.12xlarge",
 		"r6g.16xlarge",
 		"r6g.2xlarge",
 		"r6g.4xlarge",
 		"r6g.8xlarge",
 		"r6g.xlarge",
+		"r6gd.12xlarge",
+		"r6gd.16xlarge",
+		"r6gd.2xlarge",
+		"r6gd.4xlarge",
+		"r6gd.8xlarge",
+		"r6gd.xlarge",
 		"x1.32xlarge",
 		"z1d.12xlarge",
 		"z1d.2xlarge",

--- a/pkg/selector/emr_test.go
+++ b/pkg/selector/emr_test.go
@@ -46,6 +46,24 @@ func TestEMRDefaultService(t *testing.T) {
 	h.Assert(t, *transformedFilters.VirtualizationType == "hvm", "emr should only support hvm")
 }
 
+func TestFilters_Version5_33_0(t *testing.T) {
+	registry := selector.NewRegistry()
+	registry.Register("emr", &selector.EMR{})
+
+	filters := selector.Filters{
+		Service: &emr,
+	}
+
+	emrWithVersion := "emr-" + "5.33.0"
+	filters.Service = &emrWithVersion
+	transformedFilters, err := registry.ExecuteTransforms(filters)
+	h.Ok(t, err)
+	h.Assert(t, transformedFilters != filters, " Filters should have been modified")
+	h.Assert(t, *transformedFilters.RootDeviceType == "ebs", "emr should only supports ebs")
+	h.Assert(t, *transformedFilters.VirtualizationType == "hvm", "emr should only support hvm")
+	h.Assert(t, contains(*transformedFilters.InstanceTypes, "m6gd.xlarge"), "emr version 5.33.0 should include m6gd.xlarge")
+}
+
 func TestFilters_Version5_25_0(t *testing.T) {
 	registry := selector.NewRegistry()
 	registry.Register("emr", &selector.EMR{})

--- a/pkg/sorter/sorter.go
+++ b/pkg/sorter/sorter.go
@@ -59,7 +59,7 @@ type Sorter struct {
 // based on the sorting field and direction
 //
 // sortField is a json path to a field in the instancetypes.Details struct which represents
-// the field to sort instance types by. json path must start with "$" character (Ex: "$.MemoryInfo.SizeInMiB").
+// the field to sort instance types by (Ex: ".MemoryInfo.SizeInMiB").
 //
 // sortDirection represents the direction to sort in. Valid options: "ascending", "asc", "descending", "desc".
 func NewSorter(instanceTypes []*instancetypes.Details, sortField string, sortDirection string) (*Sorter, error) {
@@ -72,6 +72,8 @@ func NewSorter(instanceTypes []*instancetypes.Details, sortField string, sortDir
 	default:
 		return nil, fmt.Errorf("invalid sort direction: %s (valid options: %s, %s, %s, %s)", sortDirection, sortAscending, sortAsc, sortDescending, sortDesc)
 	}
+
+	sortField = formatSortField(sortField)
 
 	// Create sorterNode objects for each instance type
 	sorters := []*sorterNode{}
@@ -89,6 +91,18 @@ func NewSorter(instanceTypes []*instancetypes.Details, sortField string, sortDir
 		sortField:    sortField,
 		isDescending: isDescending,
 	}, nil
+}
+
+// formatSortField reformats sortField to match the expected json path format
+// of the json lookup library. Format is unchanged if the sorting field
+// matches one of the special flags.
+func formatSortField(sortField string) string {
+	// check to see if the sorting field matched one of the special exceptions
+	if sortField == gpuCountField || sortField == inferenceAcceleratorsField {
+		return sortField
+	}
+
+	return "$" + sortField
 }
 
 // newSorterNode creates a new sorterNode object which represents the given instance type

--- a/pkg/sorter/sorter.go
+++ b/pkg/sorter/sorter.go
@@ -1,0 +1,259 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sorter
+
+import (
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/instancetypes"
+	"github.com/oliveagle/jsonpath"
+)
+
+const (
+	sortAscending  = "ascending"
+	sortAsc        = "asc"
+	sortDescending = "descending"
+	sortDesc       = "desc"
+)
+
+// sorterNode represents a sortable instance type which holds the value
+// to sort by instance sort
+type sorterNode struct {
+	instanceType *instancetypes.Details
+	fieldValue   reflect.Value
+}
+
+// Sorter is used to sort instance types based on a sorting field
+// and direction
+type Sorter struct {
+	sorters      []*sorterNode
+	sortField    string
+	isDescending bool
+}
+
+// sorterWrapper is used to internally hide the implementation of the
+// sorting interface from users
+type sorterWrapper struct {
+	sorter *Sorter
+	err    error
+}
+
+// NewSorter creates a new Sorter object to be used to sort the given instance types
+// based on the sorting field and direction
+//
+// sortField is a JSON path to a field in the instancetypes.Details struct which represents
+// the field to sort instance types by. JSON path must start with "$" character (Ex: "$.MemoryInfo.SizeInMiB").
+//
+// sortDirection represents the direction to sort in. Valid options: "ascending", "asc", "descending", "desc".
+func NewSorter(instanceTypes []*instancetypes.Details, sortField string, sortDirection string) (*Sorter, error) {
+	var isDescending bool
+	switch sortDirection {
+	case sortDescending, sortDesc:
+		isDescending = true
+	case sortAscending, sortAsc:
+		isDescending = false
+	default:
+		return nil, fmt.Errorf("invalid sort direction: %s (valid options: %s, %s, %s, %s)", sortDirection, sortAscending, sortAsc, sortDescending, sortDesc)
+	}
+
+	// Create sorterNode objects for each instance type
+	sorters := []*sorterNode{}
+	for _, instanceType := range instanceTypes {
+		newSorter, err := newSorterNode(instanceType, sortField)
+		if err != nil {
+			return nil, fmt.Errorf("error creating sorting node: %v", err)
+		}
+
+		sorters = append(sorters, newSorter)
+	}
+
+	return &Sorter{
+		sorters:      sorters,
+		sortField:    sortField,
+		isDescending: isDescending,
+	}, nil
+}
+
+// newSorterNode creates a new sorterNode object which represents the given instance type
+// and can be used in sorting of instance types based on the given sortField
+func newSorterNode(instanceType *instancetypes.Details, sortField string) (*sorterNode, error) {
+	// convert instance type into json
+	jsonInstanceType, err := json.Marshal(instanceType)
+	if err != nil {
+		return nil, err
+	}
+
+	// unmarshal json instance types in order to get proper format
+	// for json path parsing
+	var jsonData interface{}
+	err = json.Unmarshal(jsonInstanceType, &jsonData)
+	if err != nil {
+		return nil, err
+	}
+
+	// get the desired field from the json data based on the passed in
+	// json path
+	result, err := jsonpath.JsonPathLookup(jsonData, sortField)
+	if err != nil {
+		return nil, err
+	}
+
+	return &sorterNode{
+		instanceType: instanceType,
+		fieldValue:   reflect.ValueOf(result),
+	}, nil
+}
+
+// Sort the instance types in the Sorter based on the Sorter's sort field and
+// direction
+func (s *Sorter) Sort() error {
+	sortWrapper := sorterWrapper{
+		sorter: s,
+		err:    nil,
+	}
+
+	sort.Sort(&sortWrapper)
+
+	return sortWrapper.err
+}
+
+// Len returns the number of sorter nodes in the Sorter
+func (sw *sorterWrapper) Len() int {
+	s := sw.sorter
+	return len(s.sorters)
+}
+
+// Swap swaps the positions of the sorter nodes at indices i and j
+func (sw *sorterWrapper) Swap(i, j int) {
+	s := sw.sorter
+	s.sorters[i], s.sorters[j] = s.sorters[j], s.sorters[i]
+}
+
+// Less determines whether the value of the sorter node at index i
+// is less than the value of the sorter node at index j or not
+func (sw *sorterWrapper) Less(i, j int) bool {
+	s := sw.sorter
+	valI := s.sorters[i].fieldValue
+	valJ := s.sorters[j].fieldValue
+
+	less, err := isLess(valI, valJ, s.isDescending)
+	if err != nil {
+		sw.err = err
+	}
+
+	return less
+}
+
+// isLess determines whether the first value (valI) is less than the
+// second value (valJ) or not
+func isLess(valI, valJ reflect.Value, isDescending bool) (bool, error) {
+	switch valI.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		// if valJ is not an int (can occur if the other value is nil)
+		// then valI is less. This will bubble invalid values to the end
+		vaJKind := valJ.Kind()
+		if vaJKind != reflect.Int && vaJKind != reflect.Int8 && vaJKind != reflect.Int16 && vaJKind != reflect.Int32 && vaJKind != reflect.Int64 {
+			return true, nil
+		}
+
+		if isDescending {
+			return valI.Int() > valJ.Int(), nil
+		} else {
+			return valI.Int() <= valJ.Int(), nil
+		}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		// if valJ is not a uint (can occur if the other value is nil)
+		// then valI is less. This will bubble invalid values to the end
+		vaJKind := valJ.Kind()
+		if vaJKind != reflect.Uint && vaJKind != reflect.Uint8 && vaJKind != reflect.Uint16 && vaJKind != reflect.Uint32 && vaJKind != reflect.Uint64 {
+			return true, nil
+		}
+
+		if isDescending {
+			return valI.Uint() > valJ.Uint(), nil
+		} else {
+			return valI.Uint() <= valJ.Uint(), nil
+		}
+	case reflect.Float32, reflect.Float64:
+		// if valJ is not a float (can occur if the other value is nil)
+		// then valI is less. This will bubble invalid values to the end
+		vaJKind := valJ.Kind()
+		if vaJKind != reflect.Float32 && vaJKind != reflect.Float64 {
+			return true, nil
+		}
+
+		if isDescending {
+			return valI.Float() > valJ.Float(), nil
+		} else {
+			return valI.Float() <= valJ.Float(), nil
+		}
+	case reflect.String:
+		// if valJ is not a string (can occur if the other value is nil)
+		// then valI is less. This will bubble invalid values to the end
+		if valJ.Kind() != reflect.String {
+			return true, nil
+		}
+
+		if isDescending {
+			return strings.Compare(valI.String(), valJ.String()) > 0, nil
+		} else {
+			return strings.Compare(valI.String(), valJ.String()) <= 0, nil
+		}
+	case reflect.Pointer:
+		// Handle nil values by making non nil values always less than the nil values. That way the
+		// nil values can be bubbled up to the end of the list.
+		if valI.IsNil() {
+			return false, nil
+		} else if valJ.Kind() != reflect.Pointer || valJ.IsNil() {
+			return true, nil
+		}
+
+		return isLess(valI.Elem(), valJ.Elem(), isDescending)
+	case reflect.Bool:
+		// if valJ is not a bool (can occur if the other value is nil)
+		// then valI is less. This will bubble invalid values to the end
+		if valJ.Kind() != reflect.Bool {
+			return true, nil
+		}
+
+		if isDescending {
+			return !valI.Bool(), nil
+		} else {
+			return valI.Bool(), nil
+		}
+	case reflect.Invalid:
+		// handle invalid values (like nil values) by making valid values
+		// always less than the invalid values. That way the invalid values
+		// always bubble up to the end of the list
+		return false, nil
+	default:
+		// unsortable value
+		return false, fmt.Errorf("unsortable value")
+	}
+}
+
+// InstanceTypes returns the list of instance types held in the Sorter
+func (s *Sorter) InstanceTypes() []*instancetypes.Details {
+	instanceTypes := []*instancetypes.Details{}
+
+	for _, node := range s.sorters {
+		instanceTypes = append(instanceTypes, node.instanceType)
+	}
+
+	return instanceTypes
+}

--- a/pkg/sorter/sorter.go
+++ b/pkg/sorter/sorter.go
@@ -161,6 +161,10 @@ func newSorterNode(instanceType *instancetypes.Details, sortField string) (*sort
 // Sort the instance types in the Sorter based on the Sorter's sort field and
 // direction
 func (s *Sorter) Sort() error {
+	if len(s.sorters) <= 1 {
+		return nil
+	}
+
 	var sortErr error = nil
 
 	sort.Slice(s.sorters, func(i int, j int) bool {

--- a/pkg/sorter/sorter.go
+++ b/pkg/sorter/sorter.go
@@ -34,7 +34,7 @@ const (
 	sortDesc       = "desc"
 
 	// Not all fields can be reached through a json path (Ex: gpu count)
-	// so have special flags for such cases.
+	// so we have special flags for such cases.
 
 	gpuCountField              = "gpus"
 	inferenceAcceleratorsField = "inference-accelerators"

--- a/pkg/sorter/sorter.go
+++ b/pkg/sorter/sorter.go
@@ -74,7 +74,7 @@ func Sort(instanceTypes []*instancetypes.Details, sortField string, sortDirectio
 	return sorter.instanceTypes(), nil
 }
 
-// NewSorter creates a new Sorter object to be used to sort the given instance types
+// newSorter creates a new Sorter object to be used to sort the given instance types
 // based on the sorting field and direction
 //
 // sortField is a json path to a field in the instancetypes.Details struct which represents

--- a/pkg/sorter/sorter_test.go
+++ b/pkg/sorter/sorter_test.go
@@ -143,7 +143,7 @@ func TestSort_EmptyList(t *testing.T) {
 	sortedInstances, err := sorter.Sort(instanceTypes, sortField, sortDirection)
 
 	h.Ok(t, err)
-	h.Assert(t, len(sortedInstances) == 0, fmt.Sprintf("sorter instance types list should be empty but actually has %d elements", len(sortedInstances)))
+	h.Assert(t, len(sortedInstances) == 0, fmt.Sprintf("Sorted instance types list should be empty but actually has %d elements", len(sortedInstances)))
 }
 
 func TestSort_InvalidSortField(t *testing.T) {

--- a/pkg/sorter/sorter_test.go
+++ b/pkg/sorter/sorter_test.go
@@ -1,0 +1,407 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package sorter_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"strings"
+	"testing"
+
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/instancetypes"
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector/outputs"
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/sorter"
+	h "github.com/aws/amazon-ec2-instance-selector/v2/pkg/test"
+)
+
+const (
+	mockFilesPath              = "../../test/static"
+	describeInstanceTypesPages = "DescribeInstanceTypesPages"
+)
+
+// Helpers
+
+// getInstanceTypeDetails unmarshalls the json file in the given testing folder
+// and returns a list of instance type details
+func getInstanceTypeDetails(t *testing.T, file string) []*instancetypes.Details {
+	folder := "FilterVerbose"
+	mockFilename := fmt.Sprintf("%s/%s/%s", mockFilesPath, folder, file)
+	mockFile, err := ioutil.ReadFile(mockFilename)
+	h.Assert(t, err == nil, "Error reading mock file "+string(mockFilename))
+
+	instanceTypes := []*instancetypes.Details{}
+	err = json.Unmarshal(mockFile, &instanceTypes)
+	h.Assert(t, err == nil, fmt.Sprintf("Error parsing mock json file contents %s. Error: %v", mockFilename, err))
+	return instanceTypes
+}
+
+// checkSortResults is a helper function for comparing the results of sorting tests. Returns true if
+// the order of instance types in the instanceTypes list matches the the order of instance type names
+// in the expectedResult list, and returns false otherwise.
+func checkSortResults(instanceTypes []*instancetypes.Details, expectedResult []string) bool {
+	if len(instanceTypes) != len(expectedResult) {
+		return false
+	}
+
+	for i := 0; i < len(instanceTypes); i++ {
+		actualName := instanceTypes[i].InstanceTypeInfo.InstanceType
+		expectedName := expectedResult[i]
+
+		if actualName == nil || *actualName != expectedName {
+			return false
+		}
+	}
+
+	return true
+}
+
+// Tests
+
+func TestNewSorter_JSONPath(t *testing.T) {
+	instanceTypes := getInstanceTypeDetails(t, "3_instances.json")
+
+	sortField := ".MemoryInfo.SizeInMiB"
+	sortDirection := "asc"
+
+	result, err := sorter.NewSorter(instanceTypes, sortField, sortDirection)
+
+	h.Ok(t, err)
+	h.Assert(t, result != nil, "Returned sorter should not be nil")
+}
+
+func TestNewSorter_SpecialCases(t *testing.T) {
+	instanceTypes := getInstanceTypeDetails(t, "3_instances.json")
+
+	// test gpus flag
+	sortField := "gpus"
+	sortDirection := "asc"
+
+	result, err := sorter.NewSorter(instanceTypes, sortField, sortDirection)
+
+	h.Ok(t, err)
+	h.Assert(t, result != nil, "Returned sorter should not be nil")
+
+	// test inference accelerators flag
+	sortField = "inference-accelerators"
+
+	result, err = sorter.NewSorter(instanceTypes, sortField, sortDirection)
+
+	h.Ok(t, err)
+	h.Assert(t, result != nil, "Returned sorter should not be nil")
+}
+
+func TestNewSorter_OneElement(t *testing.T) {
+	instanceTypes := getInstanceTypeDetails(t, "1_instance.json")
+
+	sortField := ".MemoryInfo.SizeInMiB"
+	sortDirection := "asc"
+
+	result, err := sorter.NewSorter(instanceTypes, sortField, sortDirection)
+
+	h.Ok(t, err)
+	h.Assert(t, result != nil, "Returned sorter should not be nil")
+}
+
+func TestNewSorter_EmptyList(t *testing.T) {
+	instanceTypes := []*instancetypes.Details{}
+
+	sortField := ".MemoryInfo.SizeInMiB"
+	sortDirection := "asc"
+
+	result, err := sorter.NewSorter(instanceTypes, sortField, sortDirection)
+
+	h.Ok(t, err)
+	h.Assert(t, result != nil, "Returned sorter should not be nil")
+}
+
+func TestNewSorter_InvalidSortField(t *testing.T) {
+	instanceTypes := getInstanceTypeDetails(t, "3_instances.json")
+
+	sortField := "fdsafdsafdjskalfjlsf #@"
+	sortDirection := "asc"
+
+	result, err := sorter.NewSorter(instanceTypes, sortField, sortDirection)
+
+	h.Assert(t, err != nil, "An error should be returned")
+	h.Assert(t, result == nil, "Returned sorter should be nil")
+}
+
+func TestNewSorter_InvalidDirection(t *testing.T) {
+	instanceTypes := getInstanceTypeDetails(t, "3_instances.json")
+
+	sortField := ".MemoryInfo.SizeInMiB"
+	sortDirection := "fdsa hfd j2 $#21"
+
+	result, err := sorter.NewSorter(instanceTypes, sortField, sortDirection)
+
+	h.Assert(t, err != nil, "An error should be returned")
+	h.Assert(t, result == nil, "Returned sorter should be nil")
+}
+
+func TestInstanceTypes(t *testing.T) {
+	instanceTypes := getInstanceTypeDetails(t, "3_instances.json")
+
+	sortField := ".MemoryInfo.SizeInMiB"
+	sortDirection := "asc"
+
+	result, err := sorter.NewSorter(instanceTypes, sortField, sortDirection)
+	h.Ok(t, err)
+
+	sorterInstances := result.InstanceTypes()
+
+	h.Assert(t,
+		len(sorterInstances) == len(instanceTypes),
+		fmt.Sprintf("returned instance types list should have %d elements but actually has %d elements.",
+			len(instanceTypes),
+			len(sorterInstances),
+		),
+	)
+	for i := range instanceTypes {
+		h.Assert(t,
+			*instanceTypes[i].InstanceType == *sorterInstances[i].InstanceType,
+			fmt.Sprintf("Instance types in sorter (%s) should be the same as original list (%s).",
+				strings.Join(outputs.OneLineOutput(instanceTypes), ", "),
+				strings.Join(outputs.OneLineOutput(sorterInstances), ", "),
+			),
+		)
+	}
+	h.Assert(t,
+		len(sorterInstances) == len(instanceTypes),
+		fmt.Sprintf("Instance types in sorter (%s) should be the same as original list (%s).",
+			strings.Join(outputs.OneLineOutput(instanceTypes), ", "),
+			strings.Join(outputs.OneLineOutput(sorterInstances), ", "),
+		),
+	)
+}
+
+func TestSort_Number(t *testing.T) {
+	// All numbers (ints and floats) are evaluated as floats
+	// due to the way that json unmarshalling must be done
+	// in order to match json path library input format
+
+	instanceTypes := getInstanceTypeDetails(t, "3_instances.json")
+
+	// test ascending
+	sortField := ".MemoryInfo.SizeInMiB"
+	sortDirection := "asc"
+
+	result, err := sorter.NewSorter(instanceTypes, sortField, sortDirection)
+	h.Ok(t, err)
+
+	err = result.Sort()
+	h.Ok(t, err)
+
+	sorterInstances := result.InstanceTypes()
+	expectedResults := []string{
+		"a1.large",
+		"a1.2xlarge",
+		"a1.4xlarge",
+	}
+	h.Assert(t, checkSortResults(sorterInstances, expectedResults), fmt.Sprintf("Expected ascending order: [%s], but actual order: %s", strings.Join(expectedResults, ","), outputs.OneLineOutput(sorterInstances)))
+
+	// test descending
+	sortDirection = "desc"
+
+	result, err = sorter.NewSorter(instanceTypes, sortField, sortDirection)
+	h.Ok(t, err)
+
+	err = result.Sort()
+	h.Ok(t, err)
+
+	sorterInstances = result.InstanceTypes()
+	expectedResults = []string{
+		"a1.4xlarge",
+		"a1.2xlarge",
+		"a1.large",
+	}
+	h.Assert(t, checkSortResults(sorterInstances, expectedResults), fmt.Sprintf("Expected descending order: [%s], but actual order: %s", strings.Join(expectedResults, ","), outputs.OneLineOutput(sorterInstances)))
+}
+
+func TestSort_String(t *testing.T) {
+	instanceTypes := getInstanceTypeDetails(t, "3_instances.json")
+
+	// test ascending
+	sortField := ".InstanceType"
+	sortDirection := "asc"
+
+	result, err := sorter.NewSorter(instanceTypes, sortField, sortDirection)
+	h.Ok(t, err)
+
+	err = result.Sort()
+	h.Ok(t, err)
+
+	sorterInstances := result.InstanceTypes()
+	expectedResults := []string{
+		"a1.2xlarge",
+		"a1.4xlarge",
+		"a1.large",
+	}
+	h.Assert(t, checkSortResults(sorterInstances, expectedResults), fmt.Sprintf("Expected ascending order: [%s], but actual order: %s", strings.Join(expectedResults, ","), outputs.OneLineOutput(sorterInstances)))
+
+	// test descending
+	sortDirection = "desc"
+
+	result, err = sorter.NewSorter(instanceTypes, sortField, sortDirection)
+	h.Ok(t, err)
+
+	err = result.Sort()
+	h.Ok(t, err)
+
+	sorterInstances = result.InstanceTypes()
+	expectedResults = []string{
+		"a1.large",
+		"a1.4xlarge",
+		"a1.2xlarge",
+	}
+	h.Assert(t, checkSortResults(sorterInstances, expectedResults), fmt.Sprintf("Expected descending order: [%s], but actual order: %s", strings.Join(expectedResults, ","), outputs.OneLineOutput(sorterInstances)))
+}
+
+func TestSort_Invalid(t *testing.T) {
+	instanceTypes := getInstanceTypeDetails(t, "3_instances.json")
+
+	// test ascending
+	sortField := ".SpotPrice"
+	sortDirection := "asc"
+
+	result, err := sorter.NewSorter(instanceTypes, sortField, sortDirection)
+	h.Ok(t, err)
+
+	err = result.Sort()
+	h.Ok(t, err)
+
+	sorterInstances := result.InstanceTypes()
+	expectedResults := []string{
+		"a1.large",
+		"a1.2xlarge",
+		"a1.4xlarge",
+	}
+	h.Assert(t, checkSortResults(sorterInstances, expectedResults), fmt.Sprintf("Expected ascending order: [%s], but actual order: %s", strings.Join(expectedResults, ","), outputs.OneLineOutput(sorterInstances)))
+
+	// test descending
+	sortDirection = "desc"
+
+	result, err = sorter.NewSorter(instanceTypes, sortField, sortDirection)
+	h.Ok(t, err)
+
+	err = result.Sort()
+	h.Ok(t, err)
+
+	sorterInstances = result.InstanceTypes()
+	expectedResults = []string{
+		"a1.2xlarge",
+		"a1.large",
+		"a1.4xlarge",
+	}
+	h.Assert(t, checkSortResults(sorterInstances, expectedResults), fmt.Sprintf("Expected descending order: [%s], but actual order: %s", strings.Join(expectedResults, ","), outputs.OneLineOutput(sorterInstances)))
+}
+
+func TestSort_Unsortable(t *testing.T) {
+	instanceTypes := getInstanceTypeDetails(t, "3_instances.json")
+
+	sortField := ".NetworkInfo"
+	sortDirection := "asc"
+
+	result, err := sorter.NewSorter(instanceTypes, sortField, sortDirection)
+	h.Ok(t, err)
+
+	err = result.Sort()
+	h.Assert(t, err != nil, "An error should be returned")
+}
+
+func TestSort_Pointer(t *testing.T) {
+	instanceTypes := getInstanceTypeDetails(t, "3_instances.json")
+
+	sortField := ".EbsInfo"
+	sortDirection := "asc"
+
+	result, err := sorter.NewSorter(instanceTypes, sortField, sortDirection)
+	h.Ok(t, err)
+
+	err = result.Sort()
+	h.Assert(t, err != nil, "An error should be returned")
+}
+
+func TestSort_Bool(t *testing.T) {
+	instanceTypes := getInstanceTypeDetails(t, "3_instances.json")
+
+	// test ascending
+	sortField := ".HibernationSupported"
+	sortDirection := "asc"
+
+	result, err := sorter.NewSorter(instanceTypes, sortField, sortDirection)
+	h.Ok(t, err)
+
+	err = result.Sort()
+	h.Ok(t, err)
+
+	sorterInstances := result.InstanceTypes()
+	expectedResults := []string{
+		"a1.4xlarge",
+		"a1.2xlarge",
+		"a1.large",
+	}
+	h.Assert(t, checkSortResults(sorterInstances, expectedResults), fmt.Sprintf("Expected ascending order: [%s], but actual order: %s", strings.Join(expectedResults, ","), outputs.OneLineOutput(sorterInstances)))
+
+	// test descending
+	sortDirection = "desc"
+
+	result, err = sorter.NewSorter(instanceTypes, sortField, sortDirection)
+	h.Ok(t, err)
+
+	err = result.Sort()
+	h.Ok(t, err)
+
+	sorterInstances = result.InstanceTypes()
+	expectedResults = []string{
+		"a1.large",
+		"a1.2xlarge",
+		"a1.4xlarge",
+	}
+	h.Assert(t, checkSortResults(sorterInstances, expectedResults), fmt.Sprintf("Expected descending order: [%s], but actual order: %s", strings.Join(expectedResults, ","), outputs.OneLineOutput(sorterInstances)))
+}
+
+func TestSort_EmptyList(t *testing.T) {
+	instanceTypes := []*instancetypes.Details{}
+
+	sortField := ".HibernationSupported"
+	sortDirection := "asc"
+
+	result, err := sorter.NewSorter(instanceTypes, sortField, sortDirection)
+	h.Ok(t, err)
+
+	err = result.Sort()
+	h.Ok(t, err)
+
+	sorterInstances := result.InstanceTypes()
+	h.Assert(t, len(sorterInstances) == 0, fmt.Sprintf("sorter instance types list should be empty but actually has %d elements", len(sorterInstances)))
+}
+
+func TestSort_OneElement(t *testing.T) {
+	instanceTypes := getInstanceTypeDetails(t, "1_instance.json")
+
+	sortField := ".HibernationSupported"
+	sortDirection := "asc"
+
+	result, err := sorter.NewSorter(instanceTypes, sortField, sortDirection)
+	h.Ok(t, err)
+
+	err = result.Sort()
+	h.Ok(t, err)
+
+	sorterInstances := result.InstanceTypes()
+	expectedResults := []string{"a1.2xlarge"}
+	h.Assert(t, len(sorterInstances) == 1, fmt.Sprintf("sorter instance types list should have 1 element actually has %d elements", len(sorterInstances)))
+	h.Assert(t, checkSortResults(sorterInstances, expectedResults), fmt.Sprintf("Expected ascending order: [%s], but actual order: %s", strings.Join(expectedResults, ","), outputs.OneLineOutput(sorterInstances)))
+}

--- a/test/static/FilterVerbose/1_instance.json
+++ b/test/static/FilterVerbose/1_instance.json
@@ -1,0 +1,89 @@
+[
+    {
+        "AutoRecoverySupported": true,
+        "BareMetal": false,
+        "BurstablePerformanceSupported": false,
+        "CurrentGeneration": false,
+        "DedicatedHostsSupported": true,
+        "EbsInfo": {
+            "EbsOptimizedInfo": {
+                "BaselineBandwidthInMbps": 1750,
+                "BaselineIops": 10000,
+                "BaselineThroughputInMBps": 218.75,
+                "MaximumBandwidthInMbps": 3500,
+                "MaximumIops": 20000,
+                "MaximumThroughputInMBps": 437.5
+            },
+            "EbsOptimizedSupport": "default",
+            "EncryptionSupport": "supported",
+            "NvmeSupport": "required"
+        },
+        "FpgaInfo": null,
+        "FreeTierEligible": false,
+        "GpuInfo": null,
+        "HibernationSupported": false,
+        "Hypervisor": "nitro",
+        "InferenceAcceleratorInfo": null,
+        "InstanceStorageInfo": null,
+        "InstanceStorageSupported": false,
+        "InstanceType": "a1.2xlarge",
+        "MemoryInfo": {
+            "SizeInMiB": 16384
+        },
+        "NetworkInfo": {
+            "DefaultNetworkCardIndex": 0,
+            "EfaInfo": null,
+            "EfaSupported": false,
+            "EnaSupport": "required",
+            "EncryptionInTransitSupported": false,
+            "Ipv4AddressesPerInterface": 15,
+            "Ipv6AddressesPerInterface": 15,
+            "Ipv6Supported": true,
+            "MaximumNetworkCards": 1,
+            "MaximumNetworkInterfaces": 4,
+            "NetworkCards": [
+                {
+                    "MaximumNetworkInterfaces": 4,
+                    "NetworkCardIndex": 0,
+                    "NetworkPerformance": "Up to 10 Gigabit"
+                }
+            ],
+            "NetworkPerformance": "Up to 10 Gigabit"
+        },
+        "PlacementGroupInfo": {
+            "SupportedStrategies": [
+                "cluster",
+                "partition",
+                "spread"
+            ]
+        },
+        "ProcessorInfo": {
+            "SupportedArchitectures": [
+                "arm64"
+            ],
+            "SustainedClockSpeedInGhz": 2.3
+        },
+        "SupportedBootModes": [
+            "uefi"
+        ],
+        "SupportedRootDeviceTypes": [
+            "ebs"
+        ],
+        "SupportedUsageClasses": [
+            "on-demand",
+            "spot"
+        ],
+        "SupportedVirtualizationTypes": [
+            "hvm"
+        ],
+        "VCpuInfo": {
+            "DefaultCores": 8,
+            "DefaultThreadsPerCore": 1,
+            "DefaultVCpus": 8,
+            "ValidCores": null,
+            "ValidThreadsPerCore": null
+        },
+        "OndemandPricePerHour": 0.204,
+        "SpotPrice": 0.03939999999999999
+    }
+]

--- a/test/static/FilterVerbose/3_instances.json
+++ b/test/static/FilterVerbose/3_instances.json
@@ -1,0 +1,263 @@
+[
+    {
+        "AutoRecoverySupported": true,
+        "BareMetal": false,
+        "BurstablePerformanceSupported": false,
+        "CurrentGeneration": false,
+        "DedicatedHostsSupported": true,
+        "EbsInfo": {
+            "EbsOptimizedInfo": {
+                "BaselineBandwidthInMbps": 1750,
+                "BaselineIops": 10000,
+                "BaselineThroughputInMBps": 218.75,
+                "MaximumBandwidthInMbps": 3500,
+                "MaximumIops": 20000,
+                "MaximumThroughputInMBps": 437.5
+            },
+            "EbsOptimizedSupport": "default",
+            "EncryptionSupport": "supported",
+            "NvmeSupport": "required"
+        },
+        "FpgaInfo": null,
+        "FreeTierEligible": false,
+        "GpuInfo": null,
+        "HibernationSupported": false,
+        "Hypervisor": "nitro",
+        "InferenceAcceleratorInfo": null,
+        "InstanceStorageInfo": null,
+        "InstanceStorageSupported": false,
+        "InstanceType": "a1.2xlarge",
+        "MemoryInfo": {
+            "SizeInMiB": 16384
+        },
+        "NetworkInfo": {
+            "DefaultNetworkCardIndex": 0,
+            "EfaInfo": null,
+            "EfaSupported": false,
+            "EnaSupport": "required",
+            "EncryptionInTransitSupported": false,
+            "Ipv4AddressesPerInterface": 15,
+            "Ipv6AddressesPerInterface": 15,
+            "Ipv6Supported": true,
+            "MaximumNetworkCards": 1,
+            "MaximumNetworkInterfaces": 4,
+            "NetworkCards": [
+                {
+                    "MaximumNetworkInterfaces": 4,
+                    "NetworkCardIndex": 0,
+                    "NetworkPerformance": "Up to 10 Gigabit"
+                }
+            ],
+            "NetworkPerformance": "Up to 10 Gigabit"
+        },
+        "PlacementGroupInfo": {
+            "SupportedStrategies": [
+                "cluster",
+                "partition",
+                "spread"
+            ]
+        },
+        "ProcessorInfo": {
+            "SupportedArchitectures": [
+                "arm64"
+            ],
+            "SustainedClockSpeedInGhz": 2.3
+        },
+        "SupportedBootModes": [
+            "uefi"
+        ],
+        "SupportedRootDeviceTypes": [
+            "ebs"
+        ],
+        "SupportedUsageClasses": [
+            "on-demand",
+            "spot"
+        ],
+        "SupportedVirtualizationTypes": [
+            "hvm"
+        ],
+        "VCpuInfo": {
+            "DefaultCores": 8,
+            "DefaultThreadsPerCore": 1,
+            "DefaultVCpus": 8,
+            "ValidCores": null,
+            "ValidThreadsPerCore": null
+        },
+        "OndemandPricePerHour": 0.204,
+        "SpotPrice": 0.03939999999999999
+    },
+    {
+        "AutoRecoverySupported": true,
+        "BareMetal": false,
+        "BurstablePerformanceSupported": false,
+        "CurrentGeneration": false,
+        "DedicatedHostsSupported": true,
+        "EbsInfo": {
+            "EbsOptimizedInfo": {
+                "BaselineBandwidthInMbps": 3500,
+                "BaselineIops": 20000,
+                "BaselineThroughputInMBps": 437.5,
+                "MaximumBandwidthInMbps": 3500,
+                "MaximumIops": 20000,
+                "MaximumThroughputInMBps": 437.5
+            },
+            "EbsOptimizedSupport": "default",
+            "EncryptionSupport": "supported",
+            "NvmeSupport": "required"
+        },
+        "FpgaInfo": null,
+        "FreeTierEligible": false,
+        "GpuInfo": null,
+        "HibernationSupported": true,
+        "Hypervisor": "nitro",
+        "InferenceAcceleratorInfo": null,
+        "InstanceStorageInfo": null,
+        "InstanceStorageSupported": false,
+        "InstanceType": "a1.4xlarge",
+        "MemoryInfo": {
+            "SizeInMiB": 32768
+        },
+        "NetworkInfo": {
+            "DefaultNetworkCardIndex": 0,
+            "EfaInfo": null,
+            "EfaSupported": false,
+            "EnaSupport": "required",
+            "EncryptionInTransitSupported": false,
+            "Ipv4AddressesPerInterface": 30,
+            "Ipv6AddressesPerInterface": 30,
+            "Ipv6Supported": true,
+            "MaximumNetworkCards": 1,
+            "MaximumNetworkInterfaces": 8,
+            "NetworkCards": [
+                {
+                    "MaximumNetworkInterfaces": 8,
+                    "NetworkCardIndex": 0,
+                    "NetworkPerformance": "Up to 10 Gigabit"
+                }
+            ],
+            "NetworkPerformance": "Up to 10 Gigabit"
+        },
+        "PlacementGroupInfo": {
+            "SupportedStrategies": [
+                "cluster",
+                "partition",
+                "spread"
+            ]
+        },
+        "ProcessorInfo": {
+            "SupportedArchitectures": [
+                "arm64"
+            ],
+            "SustainedClockSpeedInGhz": 2.3
+        },
+        "SupportedBootModes": [
+            "uefi"
+        ],
+        "SupportedRootDeviceTypes": [
+            "ebs"
+        ],
+        "SupportedUsageClasses": [
+            "on-demand",
+            "spot"
+        ],
+        "SupportedVirtualizationTypes": [
+            "hvm"
+        ],
+        "VCpuInfo": {
+            "DefaultCores": 16,
+            "DefaultThreadsPerCore": 1,
+            "DefaultVCpus": 16,
+            "ValidCores": null,
+            "ValidThreadsPerCore": null
+        },
+        "OndemandPricePerHour": 0.408,
+        "SpotPrice": null
+    },
+    {
+        "AutoRecoverySupported": true,
+        "BareMetal": false,
+        "BurstablePerformanceSupported": false,
+        "CurrentGeneration": false,
+        "DedicatedHostsSupported": true,
+        "EbsInfo": {
+            "EbsOptimizedInfo": {
+                "BaselineBandwidthInMbps": 525,
+                "BaselineIops": 4000,
+                "BaselineThroughputInMBps": 65.625,
+                "MaximumBandwidthInMbps": 3500,
+                "MaximumIops": 20000,
+                "MaximumThroughputInMBps": 437.5
+            },
+            "EbsOptimizedSupport": "default",
+            "EncryptionSupport": "supported",
+            "NvmeSupport": "required"
+        },
+        "FpgaInfo": null,
+        "FreeTierEligible": false,
+        "GpuInfo": null,
+        "HibernationSupported": false,
+        "Hypervisor": "nitro",
+        "InferenceAcceleratorInfo": null,
+        "InstanceStorageInfo": null,
+        "InstanceStorageSupported": false,
+        "InstanceType": "a1.large",
+        "MemoryInfo": {
+            "SizeInMiB": 4096
+        },
+        "NetworkInfo": {
+            "DefaultNetworkCardIndex": 0,
+            "EfaInfo": null,
+            "EfaSupported": false,
+            "EnaSupport": "required",
+            "EncryptionInTransitSupported": false,
+            "Ipv4AddressesPerInterface": 10,
+            "Ipv6AddressesPerInterface": 10,
+            "Ipv6Supported": true,
+            "MaximumNetworkCards": 1,
+            "MaximumNetworkInterfaces": 3,
+            "NetworkCards": [
+                {
+                    "MaximumNetworkInterfaces": 3,
+                    "NetworkCardIndex": 0,
+                    "NetworkPerformance": "Up to 10 Gigabit"
+                }
+            ],
+            "NetworkPerformance": "Up to 10 Gigabit"
+        },
+        "PlacementGroupInfo": {
+            "SupportedStrategies": [
+                "cluster",
+                "partition",
+                "spread"
+            ]
+        },
+        "ProcessorInfo": {
+            "SupportedArchitectures": [
+                "arm64"
+            ],
+            "SustainedClockSpeedInGhz": 2.3
+        },
+        "SupportedBootModes": [
+            "uefi"
+        ],
+        "SupportedRootDeviceTypes": [
+            "ebs"
+        ],
+        "SupportedUsageClasses": [
+            "on-demand",
+            "spot"
+        ],
+        "SupportedVirtualizationTypes": [
+            "hvm"
+        ],
+        "VCpuInfo": {
+            "DefaultCores": 2,
+            "DefaultThreadsPerCore": 1,
+            "DefaultVCpus": 2,
+            "ValidCores": null,
+            "ValidThreadsPerCore": null
+        },
+        "OndemandPricePerHour": 0.051,
+        "SpotPrice": 0.009819123023512438
+    }
+]

--- a/test/static/FilterVerbose/4_special_cases.json
+++ b/test/static/FilterVerbose/4_special_cases.json
@@ -1,0 +1,460 @@
+[
+    {
+        "AutoRecoverySupported": true,
+        "BareMetal": false,
+        "BurstablePerformanceSupported": false,
+        "CurrentGeneration": true,
+        "DedicatedHostsSupported": true,
+        "EbsInfo": {
+            "EbsOptimizedInfo": {
+                "BaselineBandwidthInMbps": 19000,
+                "BaselineIops": 80000,
+                "BaselineThroughputInMBps": 2375,
+                "MaximumBandwidthInMbps": 19000,
+                "MaximumIops": 80000,
+                "MaximumThroughputInMBps": 2375
+            },
+            "EbsOptimizedSupport": "default",
+            "EncryptionSupport": "supported",
+            "NvmeSupport": "required"
+        },
+        "FpgaInfo": null,
+        "FreeTierEligible": false,
+        "GpuInfo": null,
+        "HibernationSupported": false,
+        "Hypervisor": "nitro",
+        "InferenceAcceleratorInfo": {
+            "Accelerators": [
+                {
+                    "Count": 16,
+                    "Manufacturer": "AWS",
+                    "Name": "Inferentia"
+                }
+            ]
+        },
+        "InstanceStorageInfo": null,
+        "InstanceStorageSupported": false,
+        "InstanceType": "inf1.24xlarge",
+        "MemoryInfo": {
+            "SizeInMiB": 196608
+        },
+        "NetworkInfo": {
+            "DefaultNetworkCardIndex": 0,
+            "EfaInfo": {
+                "MaximumEfaInterfaces": 1
+            },
+            "EfaSupported": true,
+            "EnaSupport": "required",
+            "EncryptionInTransitSupported": true,
+            "Ipv4AddressesPerInterface": 30,
+            "Ipv6AddressesPerInterface": 30,
+            "Ipv6Supported": true,
+            "MaximumNetworkCards": 1,
+            "MaximumNetworkInterfaces": 11,
+            "NetworkCards": [
+                {
+                    "MaximumNetworkInterfaces": 11,
+                    "NetworkCardIndex": 0,
+                    "NetworkPerformance": "100 Gigabit"
+                }
+            ],
+            "NetworkPerformance": "100 Gigabit"
+        },
+        "PlacementGroupInfo": {
+            "SupportedStrategies": [
+                "cluster",
+                "partition",
+                "spread"
+            ]
+        },
+        "ProcessorInfo": {
+            "SupportedArchitectures": [
+                "x86_64"
+            ],
+            "SustainedClockSpeedInGhz": 2.5
+        },
+        "SupportedBootModes": [
+            "legacy-bios",
+            "uefi"
+        ],
+        "SupportedRootDeviceTypes": [
+            "ebs"
+        ],
+        "SupportedUsageClasses": [
+            "on-demand",
+            "spot"
+        ],
+        "SupportedVirtualizationTypes": [
+            "hvm"
+        ],
+        "VCpuInfo": {
+            "DefaultCores": 48,
+            "DefaultThreadsPerCore": 2,
+            "DefaultVCpus": 96,
+            "ValidCores": [
+                2,
+                4,
+                6,
+                8,
+                10,
+                12,
+                14,
+                16,
+                18,
+                20,
+                22,
+                24,
+                26,
+                28,
+                30,
+                32,
+                34,
+                36,
+                38,
+                40,
+                42,
+                44,
+                46,
+                48
+            ],
+            "ValidThreadsPerCore": [
+                1,
+                2
+            ]
+        },
+        "OndemandPricePerHour": 4.721,
+        "SpotPrice": 1.4163
+    },
+    {
+        "AutoRecoverySupported": true,
+        "BareMetal": false,
+        "BurstablePerformanceSupported": false,
+        "CurrentGeneration": true,
+        "DedicatedHostsSupported": false,
+        "EbsInfo": {
+            "EbsOptimizedInfo": {
+                "BaselineBandwidthInMbps": 1190,
+                "BaselineIops": 6000,
+                "BaselineThroughputInMBps": 148.75,
+                "MaximumBandwidthInMbps": 4750,
+                "MaximumIops": 20000,
+                "MaximumThroughputInMBps": 593.75
+            },
+            "EbsOptimizedSupport": "default",
+            "EncryptionSupport": "supported",
+            "NvmeSupport": "required"
+        },
+        "FpgaInfo": null,
+        "FreeTierEligible": false,
+        "GpuInfo": null,
+        "HibernationSupported": false,
+        "Hypervisor": "nitro",
+        "InferenceAcceleratorInfo": {
+            "Accelerators": [
+                {
+                    "Count": 1,
+                    "Manufacturer": "AWS",
+                    "Name": "Inferentia"
+                }
+            ]
+        },
+        "InstanceStorageInfo": null,
+        "InstanceStorageSupported": false,
+        "InstanceType": "inf1.2xlarge",
+        "MemoryInfo": {
+            "SizeInMiB": 16384
+        },
+        "NetworkInfo": {
+            "DefaultNetworkCardIndex": 0,
+            "EfaInfo": null,
+            "EfaSupported": false,
+            "EnaSupport": "required",
+            "EncryptionInTransitSupported": true,
+            "Ipv4AddressesPerInterface": 10,
+            "Ipv6AddressesPerInterface": 10,
+            "Ipv6Supported": true,
+            "MaximumNetworkCards": 1,
+            "MaximumNetworkInterfaces": 4,
+            "NetworkCards": [
+                {
+                    "MaximumNetworkInterfaces": 4,
+                    "NetworkCardIndex": 0,
+                    "NetworkPerformance": "Up to 25 Gigabit"
+                }
+            ],
+            "NetworkPerformance": "Up to 25 Gigabit"
+        },
+        "PlacementGroupInfo": {
+            "SupportedStrategies": [
+                "cluster",
+                "partition",
+                "spread"
+            ]
+        },
+        "ProcessorInfo": {
+            "SupportedArchitectures": [
+                "x86_64"
+            ],
+            "SustainedClockSpeedInGhz": 2.5
+        },
+        "SupportedBootModes": [
+            "legacy-bios",
+            "uefi"
+        ],
+        "SupportedRootDeviceTypes": [
+            "ebs"
+        ],
+        "SupportedUsageClasses": [
+            "on-demand",
+            "spot"
+        ],
+        "SupportedVirtualizationTypes": [
+            "hvm"
+        ],
+        "VCpuInfo": {
+            "DefaultCores": 4,
+            "DefaultThreadsPerCore": 2,
+            "DefaultVCpus": 8,
+            "ValidCores": [
+                2,
+                4
+            ],
+            "ValidThreadsPerCore": [
+                1,
+                2
+            ]
+        },
+        "OndemandPricePerHour": 0.362,
+        "SpotPrice": 0.10859999999999999
+    }, 
+    {
+        "AutoRecoverySupported": true,
+        "BareMetal": false,
+        "BurstablePerformanceSupported": false,
+        "CurrentGeneration": true,
+        "DedicatedHostsSupported": true,
+        "EbsInfo": {
+            "EbsOptimizedInfo": {
+                "BaselineBandwidthInMbps": 14000,
+                "BaselineIops": 80000,
+                "BaselineThroughputInMBps": 1750,
+                "MaximumBandwidthInMbps": 14000,
+                "MaximumIops": 80000,
+                "MaximumThroughputInMBps": 1750
+            },
+            "EbsOptimizedSupport": "default",
+            "EncryptionSupport": "supported",
+            "NvmeSupport": "unsupported"
+        },
+        "FpgaInfo": null,
+        "FreeTierEligible": false,
+        "GpuInfo": {
+            "Gpus": [
+                {
+                    "Count": 4,
+                    "Manufacturer": "NVIDIA",
+                    "MemoryInfo": {
+                        "SizeInMiB": 8192
+                    },
+                    "Name": "M60"
+                }
+            ],
+            "TotalGpuMemoryInMiB": 32768
+        },
+        "HibernationSupported": false,
+        "Hypervisor": "xen",
+        "InferenceAcceleratorInfo": null,
+        "InstanceStorageInfo": null,
+        "InstanceStorageSupported": false,
+        "InstanceType": "g3.16xlarge",
+        "MemoryInfo": {
+            "SizeInMiB": 499712
+        },
+        "NetworkInfo": {
+            "DefaultNetworkCardIndex": 0,
+            "EfaInfo": null,
+            "EfaSupported": false,
+            "EnaSupport": "supported",
+            "EncryptionInTransitSupported": false,
+            "Ipv4AddressesPerInterface": 50,
+            "Ipv6AddressesPerInterface": 50,
+            "Ipv6Supported": true,
+            "MaximumNetworkCards": 1,
+            "MaximumNetworkInterfaces": 15,
+            "NetworkCards": [
+                {
+                    "MaximumNetworkInterfaces": 15,
+                    "NetworkCardIndex": 0,
+                    "NetworkPerformance": "25 Gigabit"
+                }
+            ],
+            "NetworkPerformance": "25 Gigabit"
+        },
+        "PlacementGroupInfo": {
+            "SupportedStrategies": [
+                "cluster",
+                "partition",
+                "spread"
+            ]
+        },
+        "ProcessorInfo": {
+            "SupportedArchitectures": [
+                "x86_64"
+            ],
+            "SustainedClockSpeedInGhz": 2.3
+        },
+        "SupportedBootModes": [
+            "legacy-bios"
+        ],
+        "SupportedRootDeviceTypes": [
+            "ebs"
+        ],
+        "SupportedUsageClasses": [
+            "on-demand",
+            "spot"
+        ],
+        "SupportedVirtualizationTypes": [
+            "hvm"
+        ],
+        "VCpuInfo": {
+            "DefaultCores": 32,
+            "DefaultThreadsPerCore": 2,
+            "DefaultVCpus": 64,
+            "ValidCores": [
+                2,
+                4,
+                6,
+                8,
+                10,
+                12,
+                14,
+                16,
+                18,
+                20,
+                22,
+                24,
+                26,
+                28,
+                30,
+                32
+            ],
+            "ValidThreadsPerCore": [
+                1,
+                2
+            ]
+        },
+        "OndemandPricePerHour": 4.56,
+        "SpotPrice": 1.368
+    },
+    {
+        "AutoRecoverySupported": true,
+        "BareMetal": false,
+        "BurstablePerformanceSupported": false,
+        "CurrentGeneration": true,
+        "DedicatedHostsSupported": true,
+        "EbsInfo": {
+            "EbsOptimizedInfo": {
+                "BaselineBandwidthInMbps": 3500,
+                "BaselineIops": 20000,
+                "BaselineThroughputInMBps": 437.5,
+                "MaximumBandwidthInMbps": 3500,
+                "MaximumIops": 20000,
+                "MaximumThroughputInMBps": 437.5
+            },
+            "EbsOptimizedSupport": "default",
+            "EncryptionSupport": "supported",
+            "NvmeSupport": "unsupported"
+        },
+        "FpgaInfo": null,
+        "FreeTierEligible": false,
+        "GpuInfo": {
+            "Gpus": [
+                {
+                    "Count": 1,
+                    "Manufacturer": "NVIDIA",
+                    "MemoryInfo": {
+                        "SizeInMiB": 8192
+                    },
+                    "Name": "M60"
+                }
+            ],
+            "TotalGpuMemoryInMiB": 8192
+        },
+        "HibernationSupported": false,
+        "Hypervisor": "xen",
+        "InferenceAcceleratorInfo": null,
+        "InstanceStorageInfo": null,
+        "InstanceStorageSupported": false,
+        "InstanceType": "g3.4xlarge",
+        "MemoryInfo": {
+            "SizeInMiB": 124928
+        },
+        "NetworkInfo": {
+            "DefaultNetworkCardIndex": 0,
+            "EfaInfo": null,
+            "EfaSupported": false,
+            "EnaSupport": "supported",
+            "EncryptionInTransitSupported": false,
+            "Ipv4AddressesPerInterface": 30,
+            "Ipv6AddressesPerInterface": 30,
+            "Ipv6Supported": true,
+            "MaximumNetworkCards": 1,
+            "MaximumNetworkInterfaces": 8,
+            "NetworkCards": [
+                {
+                    "MaximumNetworkInterfaces": 8,
+                    "NetworkCardIndex": 0,
+                    "NetworkPerformance": "Up to 10 Gigabit"
+                }
+            ],
+            "NetworkPerformance": "Up to 10 Gigabit"
+        },
+        "PlacementGroupInfo": {
+            "SupportedStrategies": [
+                "cluster",
+                "partition",
+                "spread"
+            ]
+        },
+        "ProcessorInfo": {
+            "SupportedArchitectures": [
+                "x86_64"
+            ],
+            "SustainedClockSpeedInGhz": 2.7
+        },
+        "SupportedBootModes": [
+            "legacy-bios"
+        ],
+        "SupportedRootDeviceTypes": [
+            "ebs"
+        ],
+        "SupportedUsageClasses": [
+            "on-demand",
+            "spot"
+        ],
+        "SupportedVirtualizationTypes": [
+            "hvm"
+        ],
+        "VCpuInfo": {
+            "DefaultCores": 8,
+            "DefaultThreadsPerCore": 2,
+            "DefaultVCpus": 16,
+            "ValidCores": [
+                1,
+                2,
+                3,
+                4,
+                5,
+                6,
+                7,
+                8
+            ],
+            "ValidThreadsPerCore": [
+                1,
+                2
+            ]
+        },
+        "OndemandPricePerHour": 1.14,
+        "SpotPrice": 0.34199999999999997
+    }
+]


### PR DESCRIPTION
Issue #, if available: #21, #52, #122

Description of changes: 
Implemented instance type sorting for CLI users through the `cmd/pkg/sorter` package. Users can specify either a json path to a field in the `instancetypes.Details` struct or they can use one of the hard-coded shorthand values, which use the quantity CLI flags as keys, in order to specify what field to sort instance types by. 

json path parsing is done through the use of the following library: https://github.com/oliveagle/jsonpath

This PR is made in response to the following comment in another PR: https://github.com/aws/amazon-ec2-instance-selector/pull/138#discussion_r922584886

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
