### PR TITLE
fix pricing sync issue 

### DIFF
--- a/pkg/ec2pricing/odpricing.go
+++ b/pkg/ec2pricing/odpricing.go
@@ -23,6 +23,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -44,6 +45,7 @@ type OnDemandPricing struct {
 	DirectoryPath  string
 	cache          *cache.Cache
 	pricingClient  pricingiface.PricingAPI
+	sync.RWMutex
 }
 
 func LoadODCacheOrNew(pricingClient pricingiface.PricingAPI, region string, fullRefreshTTL time.Duration, directoryPath string) *OnDemandPricing {
@@ -111,6 +113,8 @@ func odCacheRefreshJob(odPricing *OnDemandPricing) {
 }
 
 func (c *OnDemandPricing) Refresh() error {
+	c.Lock()
+	defer c.Unlock()
 	odInstanceTypeCosts, err := c.fetchOnDemandPricing("")
 	if err != nil {
 		return fmt.Errorf("there was a problem refreshing the on-demand instance type pricing cache: %v", err)
@@ -128,6 +132,8 @@ func (c *OnDemandPricing) Get(instanceType string) (float64, error) {
 	if cost, ok := c.cache.Get(instanceType); ok {
 		return cost.(float64), nil
 	}
+	c.RLock()
+	defer c.RUnlock()
 	costs, err := c.fetchOnDemandPricing(instanceType)
 	if err != nil {
 		return 0, fmt.Errorf("there was a problem fetching on-demand instance type pricing for %s: %v", instanceType, err)
@@ -154,6 +160,8 @@ func (c *OnDemandPricing) Save() error {
 }
 
 func (c *OnDemandPricing) Clear() error {
+	c.Lock()
+	defer c.Unlock()
 	c.cache.Flush()
 	return os.Remove(getODCacheFilePath(c.Region, c.DirectoryPath))
 }

--- a/pkg/ec2pricing/odpricing.go
+++ b/pkg/ec2pricing/odpricing.go
@@ -93,7 +93,9 @@ func loadODCacheFrom(itemTTL time.Duration, region string, expandedDirPath strin
 	if err := json.Unmarshal(cacheBytes, odCache); err != nil {
 		return nil, err
 	}
-	return cache.NewFrom(itemTTL, itemTTL, *odCache), nil
+	c := cache.NewFrom(itemTTL, itemTTL, *odCache)
+	c.DeleteExpired()
+	return c, nil
 }
 
 func getODCacheFilePath(region string, directoryPath string) string {

--- a/pkg/ec2pricing/spotpricing.go
+++ b/pkg/ec2pricing/spotpricing.go
@@ -100,7 +100,9 @@ func loadSpotCacheFrom(itemTTL time.Duration, region string, expandedDirPath str
 	if err := decoder.Decode(spotTimeSeries); err != nil {
 		return nil, err
 	}
-	return cache.NewFrom(itemTTL, itemTTL, *spotTimeSeries), nil
+	c := cache.NewFrom(itemTTL, itemTTL, *spotTimeSeries)
+	c.DeleteExpired()
+	return c, nil
 }
 
 func getSpotCacheFilePath(region string, directoryPath string) string {

--- a/pkg/selector/selector.go
+++ b/pkg/selector/selector.go
@@ -261,7 +261,7 @@ func (itf Selector) prepareFilter(filters Filters, instanceTypeInfo instancetype
 	if itf.EC2Pricing.OnDemandCacheCount() > 0 {
 		price, err := itf.EC2Pricing.GetOnDemandInstanceTypeCost(instanceTypeName)
 		if err != nil {
-			log.Printf("Could not retrieve instantaneous hourly on-demand price for instance type %s\n", instanceTypeName)
+			log.Printf("Could not retrieve instantaneous hourly on-demand price for instance type %s - %s\n", instanceTypeName, err)
 		} else {
 			instanceTypeHourlyPriceOnDemand = &price
 			instanceTypeInfo.OndemandPricePerHour = instanceTypeHourlyPriceOnDemand


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws/amazon-ec2-instance-selector/issues/129

Description of changes:
 - Fix at least one cause of pricing cache issue. 

On startup, the cache file is loaded, but all items could be expired. The expiration deletion isn't run initially on load, instead the cleanup interval is used to delete expired items. To use the cache, the number of items in the cache is expected to be non-zero, but the items could be non-zero and all expired. So first, this change deletes all expired items in the cache on initial load (which is synchronous). This change also adds a mutex to each pricing refresh so that bulk refreshes are prioritized over individual lookups. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
