### PR TITLE
Verbose View for Interactive Output

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,17 +133,18 @@ t3a.medium           2            4
 **Wide Table Output**
 ```
 $ ec2-instance-selector --memory 4 --vcpus 2 --cpu-architecture x86_64 -r us-east-1 -o table-wide
-Instance Type  VCPUs   Mem (GiB)  Hypervisor  Current Gen  Hibernation Support  CPU Arch      Network Performance  ENIs    GPUs    GPU Mem (GiB)  GPU Info  On-Demand Price/Hr  Spot Price/Hr (30d avg)
--------------  -----   ---------  ----------  -----------  -------------------  --------      -------------------  ----    ----    -------------  --------  ------------------  -----------------------
-c5.large       2       4          nitro       true         true                 x86_64        Up to 10 Gigabit     3       0       0                        $0.085              $0.04708
-c5a.large      2       4          nitro       true         false                x86_64        Up to 10 Gigabit     3       0       0                        $0.077              $0.03249
-c5ad.large     2       4          nitro       true         false                x86_64        Up to 10 Gigabit     3       0       0                        $0.086              $0.0324
-c5d.large      2       4          nitro       true         true                 x86_64        Up to 10 Gigabit     3       0       0                        $0.096              $0.03525
-c6a.large      2       4          nitro       true         false                x86_64        Up to 12.5 Gigabit   3       0       0                        $0.0765             $0.034
-c6i.large      2       4          nitro       true         false                x86_64        Up to 12.5 Gigabit   3       0       0                        $0.085              $0.03416
-t2.medium      2       4          xen         true         true                 i386, x86_64  Low to Moderate      3       0       0                        $0.0464             $0.01407
-t3.medium      2       4          nitro       true         true                 x86_64        Up to 5 Gigabit      3       0       0                        $0.0416             $0.0125
-t3a.medium     2       4          nitro       true         true                 x86_64        Up to 5 Gigabit      3       0       0                        $0.0376             $0.01431
+Instance Type  VCPUs   Mem (GiB)  Hypervisor  Current Gen  Hibernation Support  CPU Arch      Network Performance  ENIs    GPUs    GPU Mem (GiB)  GPU Info  On-Demand Price/Hr  Spot Price/Hr (30d avg)  
+-------------  -----   ---------  ----------  -----------  -------------------  --------      -------------------  ----    ----    -------------  --------  ------------------  -----------------------  
+c5.large       2       4          nitro       true         true                 x86_64        Up to 10 Gigabit     3       0       0              none      -Not Fetched-       $0.03932                 
+c5a.large      2       4          nitro       true         false                x86_64        Up to 10 Gigabit     3       0       0              none      -Not Fetched-       $0.03822                 
+c5ad.large     2       4          nitro       true         false                x86_64        Up to 10 Gigabit     3       0       0              none      -Not Fetched-       $0.03449                 
+c5d.large      2       4          nitro       true         true                 x86_64        Up to 10 Gigabit     3       0       0              none      $0.096              $0.03983                 
+c6a.large      2       4          nitro       true         false                x86_64        Up to 12.5 Gigabit   3       0       0              none      $0.0765             $0.034                   
+c6i.large      2       4          nitro       true         false                x86_64        Up to 12.5 Gigabit   3       0       0              none      $0.085              $0.03605                 
+c6id.large     2       4          nitro       true         false                x86_64        Up to 12.5 Gigabit   3       0       0              none      -Not Fetched-       $0.034                   
+t2.medium      2       4          xen         true         true                 i386, x86_64  Low to Moderate      3       0       0              none      $0.0464             $0.0139                  
+t3.medium      2       4          nitro       true         true                 x86_64        Up to 5 Gigabit      3       0       0              none      $0.0416             $0.0125                  
+t3a.medium     2       4          nitro       true         true                 x86_64        Up to 5 Gigabit      3       0       0              none      -Not Fetched-       $0.01246
 ```
 
 **Sort by memory in ascending order using shorthand**
@@ -151,16 +152,16 @@ t3a.medium     2       4          nitro       true         true                 
 $ ec2-instance-selector -r us-east-1 -o table-wide --max-results 10 --sort-by memory --sort-direction asc
 Instance Type  VCPUs   Mem (GiB)  Hypervisor  Current Gen  Hibernation Support  CPU Arch      Network Performance  ENIs    GPUs    GPU Mem (GiB)  GPU Info  On-Demand Price/Hr  Spot Price/Hr (30d avg)  
 -------------  -----   ---------  ----------  -----------  -------------------  --------      -------------------  ----    ----    -------------  --------  ------------------  -----------------------  
-t2.nano        1       0.5        xen         true         true                 i386, x86_64  Low to Moderate      2       0       0                        $0.0058             -Not Fetched-            
-t4g.nano       2       0.5        nitro       true         false                arm64         Up to 5 Gigabit      2       0       0                        $0.0042             $0.0013                  
-t3a.nano       2       0.5        nitro       true         true                 x86_64        Up to 5 Gigabit      2       0       0                        $0.0047             $0.00178                 
-t3.nano        2       0.5        nitro       true         true                 x86_64        Up to 5 Gigabit      2       0       0                        $0.0052             $0.0016                  
-t1.micro       1       0.6123     xen         false        false                i386, x86_64  Very Low             2       0       0                        $0.02               $0.00213                 
-t3a.micro      2       1          nitro       true         true                 x86_64        Up to 5 Gigabit      2       0       0                        $0.0094             $0.00332                 
-t3.micro       2       1          nitro       true         true                 x86_64        Up to 5 Gigabit      2       0       0                        $0.0104             $0.0031                  
-t2.micro       1       1          xen         true         true                 i386, x86_64  Low to Moderate      2       0       0                        $0.0116             $0.0035                  
-t4g.micro      2       1          nitro       true         false                arm64         Up to 5 Gigabit      2       0       0                        $0.0084             $0.0025                  
-m1.small       1       1.69922    xen         false        false                i386, x86_64  Low                  2       0       0                        $0.044              $0.00865
+t2.nano        1       0.5        xen         true         true                 i386, x86_64  Low to Moderate      2       0       0              none      $0.0058             -Not Fetched-            
+t4g.nano       2       0.5        nitro       true         false                arm64         Up to 5 Gigabit      2       0       0              none      $0.0042             $0.0013                  
+t3a.nano       2       0.5        nitro       true         true                 x86_64        Up to 5 Gigabit      2       0       0              none      -Not Fetched-       $0.00328                 
+t3.nano        2       0.5        nitro       true         true                 x86_64        Up to 5 Gigabit      2       0       0              none      $0.0052             $0.0016                  
+t1.micro       1       0.6123     xen         false        false                i386, x86_64  Very Low             2       0       0              none      -Not Fetched-       $0.00205                 
+t3a.micro      2       1          nitro       true         true                 x86_64        Up to 5 Gigabit      2       0       0              none      -Not Fetched-       $0.00284                 
+t3.micro       2       1          nitro       true         true                 x86_64        Up to 5 Gigabit      2       0       0              none      $0.0104             $0.0031                  
+t2.micro       1       1          xen         true         true                 i386, x86_64  Low to Moderate      2       0       0              none      -Not Fetched-       $0.0035                  
+t4g.micro      2       1          nitro       true         false                arm64         Up to 5 Gigabit      2       0       0              none      -Not Fetched-       $0.0025                  
+m1.small       1       1.69922    xen         false        false                i386, x86_64  Low                  2       0       0              none      -Not Fetched-       $0.01876
 NOTE: 547 entries were truncated, increase --max-results to see more
 ```
 Available shorthand flags: vcpus, memory, gpu-memory-total, network-interfaces, spot-price, on-demand-price, instance-storage, ebs-optimized-baseline-bandwidth, ebs-optimized-baseline-throughput, ebs-optimized-baseline-iops, gpus, inference-accelerators
@@ -170,16 +171,16 @@ Available shorthand flags: vcpus, memory, gpu-memory-total, network-interfaces, 
 $ ec2-instance-selector -r us-east-1 -o table-wide --max-results 10 --sort-by .MemoryInfo.SizeInMiB --sort-direction desc
 Instance Type      VCPUs   Mem (GiB)  Hypervisor  Current Gen  Hibernation Support  CPU Arch  Network Performance  ENIs    GPUs    GPU Mem (GiB)  GPU Info  On-Demand Price/Hr  Spot Price/Hr (30d avg)  
 -------------      -----   ---------  ----------  -----------  -------------------  --------  -------------------  ----    ----    -------------  --------  ------------------  -----------------------  
-u-12tb1.112xlarge  448     12,288     nitro       true         false                x86_64    100 Gigabit          15      0       0                        $109.2              -Not Fetched-            
-u-9tb1.112xlarge   448     9,216      nitro       true         false                x86_64    100 Gigabit          15      0       0                        $81.9               -Not Fetched-            
-u-6tb1.112xlarge   448     6,144      nitro       true         false                x86_64    100 Gigabit          15      0       0                        $54.6               -Not Fetched-            
-u-6tb1.56xlarge    224     6,144      nitro       true         false                x86_64    100 Gigabit          15      0       0                        $46.40391           -Not Fetched-            
-x2iedn.metal       128     4,096      none        true         false                x86_64    100 Gigabit          15      0       0                        $26.676             $8.0028                  
-x2iedn.32xlarge    128     4,096      nitro       true         false                x86_64    100 Gigabit          15      0       0                        $26.676             $8.0028                  
-x1e.32xlarge       128     3,904      xen         true         false                x86_64    25 Gigabit           8       0       0                        $26.688             $8.03461                 
-x2iedn.24xlarge    96      3,072      nitro       true         false                x86_64    75 Gigabit           15      0       0                        $20.007             $13.23032                
-u-3tb1.56xlarge    224     3,072      nitro       true         false                x86_64    50 Gigabit           8       0       0                        $27.3               -Not Fetched-            
-x2idn.metal        128     2,048      none        true         false                x86_64    100 Gigabit          15      0       0                        $13.338             $4.67017
+u-12tb1.112xlarge  448     12,288     nitro       true         false                x86_64    100 Gigabit          15      0       0              none      $109.2              -Not Fetched-            
+u-9tb1.112xlarge   448     9,216      nitro       true         false                x86_64    100 Gigabit          15      0       0              none      -Not Fetched-       -Not Fetched-            
+u-6tb1.112xlarge   448     6,144      nitro       true         false                x86_64    100 Gigabit          15      0       0              none      $54.6               -Not Fetched-            
+u-6tb1.56xlarge    224     6,144      nitro       true         false                x86_64    100 Gigabit          15      0       0              none      $46.40391           -Not Fetched-            
+x2iedn.metal       128     4,096      none        true         false                x86_64    100 Gigabit          15      0       0              none      $26.676             $20.92296                
+x2iedn.32xlarge    128     4,096      nitro       true         false                x86_64    100 Gigabit          15      0       0              none      $26.676             $8.70294                 
+x1e.32xlarge       128     3,904      xen         true         false                x86_64    25 Gigabit           8       0       0              none      $26.688             $8.0064                  
+x2iedn.24xlarge    96      3,072      nitro       true         false                x86_64    75 Gigabit           15      0       0              none      $20.007             $6.0021                  
+u-3tb1.56xlarge    224     3,072      nitro       true         false                x86_64    50 Gigabit           8       0       0              none      $27.3               -Not Fetched-            
+x2idn.metal        128     2,048      none        true         false                x86_64    100 Gigabit          15      0       0              none      $13.338             $7.46603
 NOTE: 547 entries were truncated, increase --max-results to see more
 ```
 JSON path must point to a field in the [instancetype.Details struct](https://github.com/aws/amazon-ec2-instance-selector/blob/5bffbf2750ee09f5f1308bdc8d4b635a2c6e2721/pkg/instancetypes/instancetypes.go#L37).

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -445,7 +445,7 @@ Full docs can be found at github.com/aws/amazon-` + binName
 	var itemsTruncated int
 	var instanceTypes []string
 	if outputFlag != nil && *outputFlag == bubbleTeaOutput {
-		p := tea.NewProgram(outputs.NewBubbleTeaModel(instanceTypesDetails))
+		p := tea.NewProgram(outputs.NewBubbleTeaModel(instanceTypesDetails), tea.WithMouseCellMotion())
 		if err := p.Start(); err != nil {
 			fmt.Printf("An error occurred when starting bubble tea: %v", err)
 			os.Exit(1)

--- a/pkg/selector/outputs/bubbletea.go
+++ b/pkg/selector/outputs/bubbletea.go
@@ -15,11 +15,13 @@ package outputs
 
 import (
 	"fmt"
+	"math"
 	"reflect"
 	"strings"
 
 	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/instancetypes"
 	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/evertras/bubble-table/table"
@@ -31,8 +33,21 @@ const (
 	headerAndFooterPadding = 7
 	headerPadding          = 2
 
+	// verbose view formatting
+	outlinePadding = 8
+
 	// controls
-	controlsString = "Controls: ↑/↓ - up/down • ←/→  - left/right • shift + ←/→ - pg up/down • q - quit"
+	tableControls   = "Controls: ↑/↓ - up/down • ←/→  - left/right • shift + ←/→ - pg up/down • enter - expand • q - quit"
+	verboseControls = "Controls: ↑/↓ or scroll wheel - up/down • enter - return to table • q - quit"
+
+	// can't get terminal dimensions on startup, so use this
+	initialDimensionVal = 30
+)
+
+const (
+	// table states
+	stateTable   = "table"
+	stateVerbose = "verbose"
 )
 
 var (
@@ -57,17 +72,36 @@ var (
 	}
 )
 
+// verboseState represents the current state of the verbose view
+type verboseState struct {
+	// model for verbose output viewport
+	viewport viewport.Model
+
+	instanceTypes []*instancetypes.Details
+
+	// the instance which the verbose output is focused on
+	focusedInstanceName *string
+}
+
 // BubbleTeaModel is used to hold the state of the bubble tea TUI
 type BubbleTeaModel struct {
+	// holds the output state of the model
+	state string
+
 	// the model for the table output
 	TableModel table.Model
+
+	// holds state for the verbose view
+	verboseView verboseState
 }
 
 // NewBubbleTeaModel initializes a new bubble tea Model which represents
 // a stylized table to display instance types
 func NewBubbleTeaModel(instanceTypes []*instancetypes.Details) BubbleTeaModel {
 	return BubbleTeaModel{
-		TableModel: createTable(instanceTypes),
+		state:       stateTable,
+		TableModel:  createTable(instanceTypes),
+		verboseView: *initVerboseView(instanceTypes),
 	}
 }
 
@@ -83,52 +117,90 @@ func (m BubbleTeaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "ctrl+c", "esc", "q":
+		case "ctrl+c", "q":
 			return m, tea.Quit
+		case "enter":
+			switch m.state {
+			case stateTable:
+				// switch from table state to verbose state
+				m.state = stateVerbose
+
+				// get focused instance type
+				rowIndex := m.TableModel.GetHighlightedRowIndex()
+				focusedInstance := m.verboseView.instanceTypes[rowIndex]
+
+				// set content of view
+				m.verboseView.focusedInstanceName = focusedInstance.InstanceType
+				m.verboseView.viewport.SetContent(VerboseInstanceTypeOutput([]*instancetypes.Details{focusedInstance})[0])
+
+				// move viewport to top of printout
+				m.verboseView.viewport.SetYOffset(0)
+			case stateVerbose:
+				// switch from verbose state to table state
+				m.state = stateTable
+			}
 		}
 	case tea.WindowSizeMsg:
 		// handle screen resizing
-
-		// This is needed to handle a bug with bubble tea
-		// where resizing causes misprints (https://github.com/Evertras/bubble-table/issues/121)
-		termenv.ClearScreen()
-
-		// handle width changes
-		m.TableModel = m.TableModel.WithMaxTotalWidth(msg.Width)
-
-		// handle height changes
-		if headerAndFooterPadding >= msg.Height {
-			// height too short to fit rows
-			m.TableModel = m.TableModel.WithPageSize(0)
-		} else {
-			newRowsPerPage := msg.Height - headerAndFooterPadding
-			m.TableModel = m.TableModel.WithPageSize(newRowsPerPage)
-		}
+		m = resizeTableView(m, msg)
+		m = resizeVerboseView(m, msg)
 	}
 
-	// update table
-	var cmd tea.Cmd
-	m.TableModel, cmd = m.TableModel.Update(msg)
+	switch m.state {
+	case stateTable:
+		// update table
+		var cmd tea.Cmd
+		m.TableModel, cmd = m.TableModel.Update(msg)
 
-	// update footer
-	controlsStr := lipgloss.NewStyle().Faint(true).Render(controlsString)
-	footerStr := fmt.Sprintf("Page: %d/%d | %s", m.TableModel.CurrentPage(), m.TableModel.MaxPages(), controlsStr)
-	m.TableModel = m.TableModel.WithStaticFooter(footerStr)
+		// update footer
+		controlsStr := lipgloss.NewStyle().Faint(true).Render(tableControls)
+		footerStr := fmt.Sprintf("Page: %d/%d | %s", m.TableModel.CurrentPage(), m.TableModel.MaxPages(), controlsStr)
+		m.TableModel = m.TableModel.WithStaticFooter(footerStr)
 
-	return m, cmd
+		return m, cmd
+	case stateVerbose:
+		// update viewport
+		var cmd tea.Cmd
+		m.verboseView.viewport, cmd = m.verboseView.viewport.Update(msg)
+		return m, cmd
+	}
+
+	return m, nil
 }
 
 // View is used by bubble tea to render the bubble tea model
 func (m BubbleTeaModel) View() string {
 	outputStr := strings.Builder{}
 
-	outputStr.WriteString(m.TableModel.View())
-	outputStr.WriteString("\n")
+	switch m.state {
+	case stateTable:
+		outputStr.WriteString(m.TableModel.View())
+		outputStr.WriteString("\n")
+	case stateVerbose:
+		// format header for viewport
+		instanceName := titleStyle.Render(*m.verboseView.focusedInstanceName)
+		line := strings.Repeat("─", int(math.Max(0, float64(m.verboseView.viewport.Width-lipgloss.Width(instanceName)))))
+		outputStr.WriteString(lipgloss.JoinHorizontal(lipgloss.Center, instanceName, line))
+		outputStr.WriteString("\n")
+
+		outputStr.WriteString(m.verboseView.viewport.View())
+		outputStr.WriteString("\n")
+
+		// format footer for viewport
+		pagePercentage := infoStyle.Render(fmt.Sprintf("%3.f%%", m.verboseView.viewport.ScrollPercent()*100))
+		line = strings.Repeat("─", int(math.Max(0, float64(m.verboseView.viewport.Width-lipgloss.Width(pagePercentage)))))
+		outputStr.WriteString(lipgloss.JoinHorizontal(lipgloss.Center, line, pagePercentage))
+		outputStr.WriteString("\n")
+
+		// controls
+		outputStr.WriteString(lipgloss.NewStyle().Faint(true).Render(verboseControls))
+		outputStr.WriteString("\n")
+	}
 
 	return outputStr.String()
 }
 
-// table creation helpers:
+// table helpers:
 
 // createRows creates a row for each instance type in the passed in list
 func createRows(columnsData []*wideColumnsData) *[]table.Row {
@@ -256,4 +328,77 @@ func createTable(instanceTypes []*instancetypes.Details) table.Model {
 		HeaderStyle(lipgloss.NewStyle().Align(lipgloss.Center).Bold(true))
 
 	return newTable
+}
+
+// resizeTableView will change the dimensions of the table in order to accommodate
+// the new window dimensions represented by the given tea.WindowSizeMsg
+func resizeTableView(model BubbleTeaModel, msg tea.WindowSizeMsg) BubbleTeaModel {
+	// This is needed to handle a bug with bubble tea
+	// where resizing causes misprints (https://github.com/Evertras/bubble-table/issues/121)
+	termenv.ClearScreen()
+
+	// handle width changes
+	model.TableModel = model.TableModel.WithMaxTotalWidth(msg.Width)
+
+	// handle height changes
+	if headerAndFooterPadding >= msg.Height {
+		// height too short to fit rows
+		model.TableModel = model.TableModel.WithPageSize(0)
+	} else {
+		newRowsPerPage := msg.Height - headerAndFooterPadding
+		model.TableModel = model.TableModel.WithPageSize(newRowsPerPage)
+	}
+
+	return model
+}
+
+// verbose helpers:
+
+// styling for viewport
+var (
+	titleStyle = func() lipgloss.Style {
+		b := lipgloss.RoundedBorder()
+		b.Right = "├"
+		return lipgloss.NewStyle().BorderStyle(b).Padding(0, 1)
+	}()
+
+	infoStyle = func() lipgloss.Style {
+		b := lipgloss.RoundedBorder()
+		b.Left = "┤"
+		return titleStyle.Copy().BorderStyle(b)
+	}()
+)
+
+// initVerboseView initializes and returns a new verboseState based on the given
+// instance type details
+func initVerboseView(instanceTypes []*instancetypes.Details) *verboseState {
+	viewportModel := viewport.New(initialDimensionVal, initialDimensionVal)
+	viewportModel.MouseWheelEnabled = true
+
+	return &verboseState{
+		viewport:      viewportModel,
+		instanceTypes: instanceTypes,
+	}
+}
+
+// resizeVerboseView will change the dimensions of the verbose viewport in order to accommodate
+// the new window dimensions represented by the given tea.WindowSizeMsg
+func resizeVerboseView(model BubbleTeaModel, msg tea.WindowSizeMsg) BubbleTeaModel {
+	// This is needed to handle a bug with bubble tea
+	// where resizing causes misprints (https://github.com/Evertras/bubble-table/issues/121)
+	termenv.ClearScreen()
+
+	// handle width changes
+	model.verboseView.viewport.Width = msg.Width
+
+	// handle height changes
+	if outlinePadding >= msg.Height {
+		// height too short to fit viewport
+		model.verboseView.viewport.Height = 0
+	} else {
+		newHeight := msg.Height - outlinePadding
+		model.verboseView.viewport.Height = newHeight
+	}
+
+	return model
 }

--- a/pkg/selector/outputs/bubbletea.go
+++ b/pkg/selector/outputs/bubbletea.go
@@ -307,9 +307,6 @@ func createKeyMap() *table.KeyMap {
 // createTable creates an intractable table which contains information about all of
 // the given instance types
 func createTable(instanceTypes []*instancetypes.Details) table.Model {
-	// can't get terminal size yet, so set temporary value
-	initialDimensionVal := 30
-
 	// calculate and fetch all column data from instance types
 	columnsData := getWideColumnsData(instanceTypes)
 

--- a/pkg/selector/outputs/bubbletea.go
+++ b/pkg/selector/outputs/bubbletea.go
@@ -38,7 +38,7 @@ const (
 
 	// controls
 	tableControls   = "Controls: ↑/↓ - up/down • ←/→  - left/right • shift + ←/→ - pg up/down • enter - expand • q - quit"
-	verboseControls = "Controls: ↑/↓ or scroll wheel - up/down • enter - return to table • q - quit"
+	verboseControls = "Controls: ↑/↓ - up/down • enter - return to table • q - quit"
 
 	// can't get terminal dimensions on startup, so use this
 	initialDimensionVal = 30

--- a/pkg/selector/outputs/bubbletea.go
+++ b/pkg/selector/outputs/bubbletea.go
@@ -14,34 +14,12 @@
 package outputs
 
 import (
-	"fmt"
-	"math"
-	"reflect"
-	"strings"
-
 	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/instancetypes"
-	"github.com/charmbracelet/bubbles/key"
-	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
-	"github.com/charmbracelet/lipgloss"
-	"github.com/evertras/bubble-table/table"
 	"github.com/muesli/termenv"
 )
 
 const (
-	// table formatting
-	headerAndFooterPadding = 7
-	headerPadding          = 2
-
-	// verbose view formatting
-	outlinePadding = 8
-
-	// controls
-	tableControls   = "Controls: ↑/↓ - up/down • ←/→  - left/right • shift + ←/→ - pg up/down • enter - expand • q - quit"
-	verboseControls = "Controls: ↑/↓ - up/down • enter - return to table • q - quit"
-
-	ellipses = "..."
-
 	// can't get terminal dimensions on startup, so use this
 	initialDimensionVal = 30
 )
@@ -52,48 +30,13 @@ const (
 	stateVerbose = "verbose"
 )
 
-var (
-	customBorder = table.Border{
-		Top:    "─",
-		Left:   "│",
-		Right:  "│",
-		Bottom: "─",
-
-		TopRight:    "╮",
-		TopLeft:     "╭",
-		BottomRight: "╯",
-		BottomLeft:  "╰",
-
-		TopJunction:    "┬",
-		LeftJunction:   "├",
-		RightJunction:  "┤",
-		BottomJunction: "┴",
-		InnerJunction:  "┼",
-
-		InnerDivider: "│",
-	}
-)
-
-// verboseModel represents the current state of the verbose view
-type verboseModel struct {
-	// model for verbose output viewport
-	viewport viewport.Model
-
-	instanceTypes []*instancetypes.Details
-
-	// the instance which the verbose output is focused on
-	focusedInstanceName *string
-}
-
 // BubbleTeaModel is used to hold the state of the bubble tea TUI
 type BubbleTeaModel struct {
 	// holds the output currentState of the model
 	currentState string
 
-	// the model for the table output
-	TableModel table.Model
-
-	tableWidth int
+	// the model for the table view
+	tableModel tableModel
 
 	// holds state for the verbose view
 	verboseModel verboseModel
@@ -104,9 +47,8 @@ type BubbleTeaModel struct {
 func NewBubbleTeaModel(instanceTypes []*instancetypes.Details) BubbleTeaModel {
 	return BubbleTeaModel{
 		currentState: stateTable,
-		TableModel:   createTable(instanceTypes),
-		tableWidth:   initialDimensionVal,
-		verboseModel: *initVerboseView(instanceTypes),
+		tableModel:   *initTableModel(instanceTypes),
+		verboseModel: *initVerboseModel(instanceTypes),
 	}
 }
 
@@ -118,9 +60,9 @@ func (m BubbleTeaModel) Init() tea.Cmd {
 // Update is used by bubble tea to update the state of the bubble
 // tea model based on user input
 func (m BubbleTeaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
-	// check for quit
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
+		// check for quit or change in state
 		switch msg.String() {
 		case "ctrl+c", "q":
 			return m, tea.Quit
@@ -131,7 +73,7 @@ func (m BubbleTeaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.currentState = stateVerbose
 
 				// get focused instance type
-				rowIndex := m.TableModel.GetHighlightedRowIndex()
+				rowIndex := m.tableModel.table.GetHighlightedRowIndex()
 				focusedInstance := m.verboseModel.instanceTypes[rowIndex]
 
 				// set content of view
@@ -151,24 +93,21 @@ func (m BubbleTeaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		termenv.ClearScreen()
 
 		// handle screen resizing
-		m = resizeTableView(m, msg)
-		m = resizeVerboseView(m, msg)
+		m.tableModel = m.tableModel.resizeView(msg)
+		m.verboseModel = m.verboseModel.resizeView(msg)
 	}
 
 	switch m.currentState {
 	case stateTable:
 		// update table
 		var cmd tea.Cmd
-		m.TableModel, cmd = m.TableModel.Update(msg)
-
-		// update footer
-		m = updateTableFooter(m)
+		m.tableModel, cmd = m.tableModel.update(msg)
 
 		return m, cmd
 	case stateVerbose:
 		// update viewport
 		var cmd tea.Cmd
-		m.verboseModel.viewport, cmd = m.verboseModel.viewport.Update(msg)
+		m.verboseModel, cmd = m.verboseModel.update(msg)
 		return m, cmd
 	}
 
@@ -177,248 +116,12 @@ func (m BubbleTeaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 // View is used by bubble tea to render the bubble tea model
 func (m BubbleTeaModel) View() string {
-	outputStr := strings.Builder{}
-
 	switch m.currentState {
 	case stateTable:
-		outputStr.WriteString(m.TableModel.View())
-		outputStr.WriteString("\n")
+		return m.tableModel.view()
 	case stateVerbose:
-		// format header for viewport
-		instanceName := titleStyle.Render(*m.verboseModel.focusedInstanceName)
-		line := strings.Repeat("─", int(math.Max(0, float64(m.verboseModel.viewport.Width-lipgloss.Width(instanceName)))))
-		outputStr.WriteString(lipgloss.JoinHorizontal(lipgloss.Center, instanceName, line))
-		outputStr.WriteString("\n")
-
-		outputStr.WriteString(m.verboseModel.viewport.View())
-		outputStr.WriteString("\n")
-
-		// format footer for viewport
-		pagePercentage := infoStyle.Render(fmt.Sprintf("%3.f%%", m.verboseModel.viewport.ScrollPercent()*100))
-		line = strings.Repeat("─", int(math.Max(0, float64(m.verboseModel.viewport.Width-lipgloss.Width(pagePercentage)))))
-		outputStr.WriteString(lipgloss.JoinHorizontal(lipgloss.Center, line, pagePercentage))
-		outputStr.WriteString("\n")
-
-		// controls
-		outputStr.WriteString(lipgloss.NewStyle().Faint(true).Render(verboseControls))
-		outputStr.WriteString("\n")
+		return m.verboseModel.view()
 	}
 
-	return outputStr.String()
-}
-
-// table helpers:
-
-// createRows creates a row for each instance type in the passed in list
-func createRows(columnsData []*wideColumnsData) *[]table.Row {
-	rows := []table.Row{}
-
-	// create a row for each instance type
-	for _, data := range columnsData {
-		rowData := table.RowData{}
-
-		// create a new row by iterating through the column data
-		// struct and using struct tags as column keys
-		structType := reflect.TypeOf(*data)
-		structValue := reflect.ValueOf(*data)
-		for i := 0; i < structType.NumField(); i++ {
-			currField := structType.Field(i)
-			columnName := currField.Tag.Get(columnTag)
-			colValue := structValue.Field(i)
-			rowData[columnName] = getUnderlyingValue(colValue)
-		}
-
-		newRow := table.NewRow(rowData)
-
-		rows = append(rows, newRow)
-	}
-
-	return &rows
-}
-
-// maxColWidth finds the maximum width element in the given column
-func maxColWidth(columnsData []*wideColumnsData, columnHeader string) int {
-	// default max width is the width of the header itself with padding
-	maxWidth := len(columnHeader) + headerPadding
-
-	for _, data := range columnsData {
-		// get data at given column
-		structType := reflect.TypeOf(*data)
-		structValue := reflect.ValueOf(*data)
-		var underlyingValue interface{}
-		for i := 0; i < structType.NumField(); i++ {
-			currField := structType.Field(i)
-			columnName := currField.Tag.Get(columnTag)
-			if columnName == columnHeader {
-				colValue := structValue.Field(i)
-				underlyingValue = getUnderlyingValue(colValue)
-				break
-			}
-		}
-
-		// see if the width of the current column element exceeds
-		// the previous max width
-		currWidth := len(fmt.Sprintf("%v", underlyingValue))
-		if currWidth > maxWidth {
-			maxWidth = currWidth
-		}
-	}
-
-	return maxWidth
-}
-
-// createColumns creates columns based on the tags in the wideColumnsData
-// struct
-func createColumns(columnsData []*wideColumnsData) *[]table.Column {
-	columns := []table.Column{}
-
-	// iterate through wideColumnsData struct and create a new column for each field tag
-	columnDataStruct := wideColumnsData{}
-	structType := reflect.TypeOf(columnDataStruct)
-	for i := 0; i < structType.NumField(); i++ {
-		columnHeader := structType.Field(i).Tag.Get(columnTag)
-		newCol := table.NewColumn(columnHeader, columnHeader, maxColWidth(columnsData, columnHeader))
-
-		columns = append(columns, newCol)
-	}
-
-	return &columns
-}
-
-// createKeyMap creates a KeyMap with the controls for the table
-func createKeyMap() *table.KeyMap {
-	keys := table.KeyMap{
-		RowDown: key.NewBinding(
-			key.WithKeys("down"),
-		),
-		RowUp: key.NewBinding(
-			key.WithKeys("up"),
-		),
-		ScrollLeft: key.NewBinding(
-			key.WithKeys("left"),
-		),
-		ScrollRight: key.NewBinding(
-			key.WithKeys("right"),
-		),
-		PageDown: key.NewBinding(
-			key.WithKeys("shift+right"),
-		),
-		PageUp: key.NewBinding(
-			key.WithKeys("shift+left"),
-		),
-	}
-
-	return &keys
-}
-
-// createTable creates an intractable table which contains information about all of
-// the given instance types
-func createTable(instanceTypes []*instancetypes.Details) table.Model {
-	// calculate and fetch all column data from instance types
-	columnsData := getWideColumnsData(instanceTypes)
-
-	newTable := table.New(*createColumns(columnsData)).
-		WithRows(*createRows(columnsData)).
-		WithKeyMap(*createKeyMap()).
-		WithPageSize(initialDimensionVal).
-		Focused(true).
-		Border(customBorder).
-		WithMaxTotalWidth(initialDimensionVal).
-		WithHorizontalFreezeColumnCount(1).
-		WithBaseStyle(
-			lipgloss.NewStyle().
-				Align((lipgloss.Left)),
-		).
-		HeaderStyle(lipgloss.NewStyle().Align(lipgloss.Center).Bold(true))
-
-	return newTable
-}
-
-// resizeTableView will change the dimensions of the table in order to accommodate
-// the new window dimensions represented by the given tea.WindowSizeMsg
-func resizeTableView(model BubbleTeaModel, msg tea.WindowSizeMsg) BubbleTeaModel {
-	// handle width changes
-	model.TableModel = model.TableModel.WithMaxTotalWidth(msg.Width)
-	model.tableWidth = msg.Width
-
-	// handle height changes
-	if headerAndFooterPadding >= msg.Height {
-		// height too short to fit rows
-		model.TableModel = model.TableModel.WithPageSize(0)
-	} else {
-		newRowsPerPage := msg.Height - headerAndFooterPadding
-		model.TableModel = model.TableModel.WithPageSize(newRowsPerPage)
-	}
-
-	return model
-}
-
-// updateTableFooter updates the page and controls string in the table footer
-func updateTableFooter(model BubbleTeaModel) BubbleTeaModel {
-	controlsStr := tableControls
-
-	// prevent controls text from wrapping to avoid table misprints
-	pageStr := fmt.Sprintf("Page: %d/%d | ", model.TableModel.CurrentPage(), model.TableModel.MaxPages())
-	if model.tableWidth < len(pageStr)+len(controlsStr) {
-		controlsWidth := model.tableWidth - len(ellipses) - len(pageStr) - 2
-		if controlsWidth < 0 {
-			controlsWidth = 0
-		} else if controlsWidth > len(tableControls) {
-			controlsWidth = len(tableControls)
-		}
-		controlsStr = tableControls[0:controlsWidth] + ellipses
-	}
-
-	renderedControls := lipgloss.NewStyle().Faint(true).Render(controlsStr)
-	footerStr := fmt.Sprintf("%s%s", pageStr, renderedControls)
-	model.TableModel = model.TableModel.WithStaticFooter(footerStr)
-
-	return model
-}
-
-// verbose helpers:
-
-// styling for viewport
-var (
-	titleStyle = func() lipgloss.Style {
-		b := lipgloss.RoundedBorder()
-		b.Right = "├"
-		return lipgloss.NewStyle().BorderStyle(b).Padding(0, 1)
-	}()
-
-	infoStyle = func() lipgloss.Style {
-		b := lipgloss.RoundedBorder()
-		b.Left = "┤"
-		return titleStyle.Copy().BorderStyle(b)
-	}()
-)
-
-// initVerboseView initializes and returns a new verboseState based on the given
-// instance type details
-func initVerboseView(instanceTypes []*instancetypes.Details) *verboseModel {
-	viewportModel := viewport.New(initialDimensionVal, initialDimensionVal)
-	viewportModel.MouseWheelEnabled = true
-
-	return &verboseModel{
-		viewport:      viewportModel,
-		instanceTypes: instanceTypes,
-	}
-}
-
-// resizeVerboseView will change the dimensions of the verbose viewport in order to accommodate
-// the new window dimensions represented by the given tea.WindowSizeMsg
-func resizeVerboseView(model BubbleTeaModel, msg tea.WindowSizeMsg) BubbleTeaModel {
-	// handle width changes
-	model.verboseModel.viewport.Width = msg.Width
-
-	// handle height changes
-	if outlinePadding >= msg.Height {
-		// height too short to fit viewport
-		model.verboseModel.viewport.Height = 0
-	} else {
-		newHeight := msg.Height - outlinePadding
-		model.verboseModel.viewport.Height = newHeight
-	}
-
-	return model
+	return ""
 }

--- a/pkg/selector/outputs/bubbletea_internal_test.go
+++ b/pkg/selector/outputs/bubbletea_internal_test.go
@@ -11,7 +11,7 @@
 // express or implied. See the License for the specific language governing
 // permissions and limitations under the License.
 
-package outputs_test
+package outputs
 
 import (
 	"encoding/json"
@@ -21,9 +21,12 @@ import (
 	"testing"
 
 	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/instancetypes"
-	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/selector/outputs"
 	h "github.com/aws/amazon-ec2-instance-selector/v2/pkg/test"
 	"github.com/evertras/bubble-table/table"
+)
+
+const (
+	mockFilesPath = "../../../test/static"
 )
 
 // helpers
@@ -59,8 +62,8 @@ func TestNewBubbleTeaModel_Hypervisor(t *testing.T) {
 	instanceTypes := getInstanceTypeDetails(t, "g3_16xlarge.json")
 
 	// test non nil Hypervisor
-	model := outputs.NewBubbleTeaModel(instanceTypes)
-	rows := model.TableModel.GetVisibleRows()
+	model := NewBubbleTeaModel(instanceTypes)
+	rows := model.tableModel.table.GetVisibleRows()
 	expectedHypervisor := "xen"
 	actualHypervisor := rows[0].Data["Hypervisor"]
 
@@ -68,8 +71,8 @@ func TestNewBubbleTeaModel_Hypervisor(t *testing.T) {
 
 	// test nil Hypervisor
 	instanceTypes[0].Hypervisor = nil
-	model = outputs.NewBubbleTeaModel(instanceTypes)
-	rows = model.TableModel.GetVisibleRows()
+	model = NewBubbleTeaModel(instanceTypes)
+	rows = model.tableModel.table.GetVisibleRows()
 	expectedHypervisor = "none"
 	actualHypervisor = rows[0].Data["Hypervisor"]
 
@@ -78,8 +81,8 @@ func TestNewBubbleTeaModel_Hypervisor(t *testing.T) {
 
 func TestNewBubbleTeaModel_CPUArchitectures(t *testing.T) {
 	instanceTypes := getInstanceTypeDetails(t, "g3_16xlarge.json")
-	model := outputs.NewBubbleTeaModel(instanceTypes)
-	rows := model.TableModel.GetVisibleRows()
+	model := NewBubbleTeaModel(instanceTypes)
+	rows := model.tableModel.table.GetVisibleRows()
 
 	actualGPUArchitectures := "x86_64"
 	expectedGPUArchitectures := rows[0].Data["CPU Arch"]
@@ -89,8 +92,8 @@ func TestNewBubbleTeaModel_CPUArchitectures(t *testing.T) {
 
 func TestNewBubbleTeaModel_GPU(t *testing.T) {
 	instanceTypes := getInstanceTypeDetails(t, "g3_16xlarge.json")
-	model := outputs.NewBubbleTeaModel(instanceTypes)
-	rows := model.TableModel.GetVisibleRows()
+	model := NewBubbleTeaModel(instanceTypes)
+	rows := model.tableModel.table.GetVisibleRows()
 
 	// test GPU count
 	expectedGPUCount := "4"
@@ -115,8 +118,8 @@ func TestNewBubbleTeaModel_ODPricing(t *testing.T) {
 	instanceTypes := getInstanceTypeDetails(t, "g3_16xlarge.json")
 
 	// test non nil OD price
-	model := outputs.NewBubbleTeaModel(instanceTypes)
-	rows := model.TableModel.GetVisibleRows()
+	model := NewBubbleTeaModel(instanceTypes)
+	rows := model.tableModel.table.GetVisibleRows()
 	expectedODPrice := "$4.56"
 	actualODPrice := fmt.Sprintf("%v", rows[0].Data["On-Demand Price/Hr"])
 
@@ -124,8 +127,8 @@ func TestNewBubbleTeaModel_ODPricing(t *testing.T) {
 
 	// test nil OD price
 	instanceTypes[0].OndemandPricePerHour = nil
-	model = outputs.NewBubbleTeaModel(instanceTypes)
-	rows = model.TableModel.GetVisibleRows()
+	model = NewBubbleTeaModel(instanceTypes)
+	rows = model.tableModel.table.GetVisibleRows()
 	expectedODPrice = "-Not Fetched-"
 	actualODPrice = fmt.Sprintf("%v", rows[0].Data["On-Demand Price/Hr"])
 
@@ -136,8 +139,8 @@ func TestNewBubbleTeaModel_SpotPricing(t *testing.T) {
 	instanceTypes := getInstanceTypeDetails(t, "g3_16xlarge.json")
 
 	// test non nil spot price
-	model := outputs.NewBubbleTeaModel(instanceTypes)
-	rows := model.TableModel.GetVisibleRows()
+	model := NewBubbleTeaModel(instanceTypes)
+	rows := model.tableModel.table.GetVisibleRows()
 	expectedODPrice := "$1.368"
 	actualODPrice := fmt.Sprintf("%v", rows[0].Data["Spot Price/Hr (30d avg)"])
 
@@ -145,8 +148,8 @@ func TestNewBubbleTeaModel_SpotPricing(t *testing.T) {
 
 	// test nil spot price
 	instanceTypes[0].SpotPrice = nil
-	model = outputs.NewBubbleTeaModel(instanceTypes)
-	rows = model.TableModel.GetVisibleRows()
+	model = NewBubbleTeaModel(instanceTypes)
+	rows = model.tableModel.table.GetVisibleRows()
 	expectedODPrice = "-Not Fetched-"
 	actualODPrice = fmt.Sprintf("%v", rows[0].Data["Spot Price/Hr (30d avg)"])
 
@@ -155,8 +158,8 @@ func TestNewBubbleTeaModel_SpotPricing(t *testing.T) {
 
 func TestNewBubbleTeaModel_Rows(t *testing.T) {
 	instanceTypes := getInstanceTypeDetails(t, "3_instances.json")
-	model := outputs.NewBubbleTeaModel(instanceTypes)
-	rows := model.TableModel.GetVisibleRows()
+	model := NewBubbleTeaModel(instanceTypes)
+	rows := model.tableModel.table.GetVisibleRows()
 
 	h.Assert(t, len(rows) == len(instanceTypes), "Number of rows should be %d, but is actually %d", len(instanceTypes), len(rows))
 
@@ -165,6 +168,6 @@ func TestNewBubbleTeaModel_Rows(t *testing.T) {
 		currInstanceName := instanceTypes[i].InstanceType
 		currRowName := rows[i].Data["Instance Type"]
 
-		h.Assert(t, *currInstanceName == currRowName, "Rows should be in following order: %s. Actual order: [%s]", outputs.OneLineOutput(instanceTypes), getRowsInstances(rows))
+		h.Assert(t, *currInstanceName == currRowName, "Rows should be in following order: %s. Actual order: [%s]", OneLineOutput(instanceTypes), getRowsInstances(rows))
 	}
 }

--- a/pkg/selector/outputs/outputs.go
+++ b/pkg/selector/outputs/outputs.go
@@ -221,6 +221,8 @@ func getWideColumnsData(instanceTypes []*instancetypes.Details) []*wideColumnsDa
 				gpus = gpus + *gpuInfo.Count
 				gpuType = append(gpuType, *gpuInfo.Manufacturer+" "+*gpuInfo.Name)
 			}
+		} else {
+			gpuType = append(gpuType, none)
 		}
 
 		onDemandPricePerHourStr := "-Not Fetched-"

--- a/pkg/selector/outputs/tableView.go
+++ b/pkg/selector/outputs/tableView.go
@@ -1,0 +1,256 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package outputs
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/instancetypes"
+	"github.com/charmbracelet/bubbles/key"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/evertras/bubble-table/table"
+)
+
+const (
+	// table formatting
+	headerAndFooterPadding = 7
+	headerPadding          = 2
+
+	// controls
+	tableControls = "Controls: ↑/↓ - up/down • ←/→  - left/right • shift + ←/→ - pg up/down • enter - expand • q - quit"
+	ellipses      = "..."
+)
+
+type tableModel struct {
+	// the model for the table output
+	table table.Model
+
+	tableWidth int
+}
+
+var (
+	customBorder = table.Border{
+		Top:    "─",
+		Left:   "│",
+		Right:  "│",
+		Bottom: "─",
+
+		TopRight:    "╮",
+		TopLeft:     "╭",
+		BottomRight: "╯",
+		BottomLeft:  "╰",
+
+		TopJunction:    "┬",
+		LeftJunction:   "├",
+		RightJunction:  "┤",
+		BottomJunction: "┴",
+		InnerJunction:  "┼",
+
+		InnerDivider: "│",
+	}
+)
+
+// initTableModel initializes and returns a new tableModel based on the given
+// instance type details
+func initTableModel(instanceTypes []*instancetypes.Details) *tableModel {
+	return &tableModel{
+		table:      createTable(instanceTypes),
+		tableWidth: initialDimensionVal,
+	}
+}
+
+// createRows creates a row for each instance type in the passed in list
+func createRows(columnsData []*wideColumnsData) *[]table.Row {
+	rows := []table.Row{}
+
+	// create a row for each instance type
+	for _, data := range columnsData {
+		rowData := table.RowData{}
+
+		// create a new row by iterating through the column data
+		// struct and using struct tags as column keys
+		structType := reflect.TypeOf(*data)
+		structValue := reflect.ValueOf(*data)
+		for i := 0; i < structType.NumField(); i++ {
+			currField := structType.Field(i)
+			columnName := currField.Tag.Get(columnTag)
+			colValue := structValue.Field(i)
+			rowData[columnName] = getUnderlyingValue(colValue)
+		}
+
+		newRow := table.NewRow(rowData)
+
+		rows = append(rows, newRow)
+	}
+
+	return &rows
+}
+
+// maxColWidth finds the maximum width element in the given column
+func maxColWidth(columnsData []*wideColumnsData, columnHeader string) int {
+	// default max width is the width of the header itself with padding
+	maxWidth := len(columnHeader) + headerPadding
+
+	for _, data := range columnsData {
+		// get data at given column
+		structType := reflect.TypeOf(*data)
+		structValue := reflect.ValueOf(*data)
+		var underlyingValue interface{}
+		for i := 0; i < structType.NumField(); i++ {
+			currField := structType.Field(i)
+			columnName := currField.Tag.Get(columnTag)
+			if columnName == columnHeader {
+				colValue := structValue.Field(i)
+				underlyingValue = getUnderlyingValue(colValue)
+				break
+			}
+		}
+
+		// see if the width of the current column element exceeds
+		// the previous max width
+		currWidth := len(fmt.Sprintf("%v", underlyingValue))
+		if currWidth > maxWidth {
+			maxWidth = currWidth
+		}
+	}
+
+	return maxWidth
+}
+
+// createColumns creates columns based on the tags in the wideColumnsData
+// struct
+func createColumns(columnsData []*wideColumnsData) *[]table.Column {
+	columns := []table.Column{}
+
+	// iterate through wideColumnsData struct and create a new column for each field tag
+	columnDataStruct := wideColumnsData{}
+	structType := reflect.TypeOf(columnDataStruct)
+	for i := 0; i < structType.NumField(); i++ {
+		columnHeader := structType.Field(i).Tag.Get(columnTag)
+		newCol := table.NewColumn(columnHeader, columnHeader, maxColWidth(columnsData, columnHeader))
+
+		columns = append(columns, newCol)
+	}
+
+	return &columns
+}
+
+// createKeyMap creates a KeyMap with the controls for the table
+func createKeyMap() *table.KeyMap {
+	keys := table.KeyMap{
+		RowDown: key.NewBinding(
+			key.WithKeys("down"),
+		),
+		RowUp: key.NewBinding(
+			key.WithKeys("up"),
+		),
+		ScrollLeft: key.NewBinding(
+			key.WithKeys("left"),
+		),
+		ScrollRight: key.NewBinding(
+			key.WithKeys("right"),
+		),
+		PageDown: key.NewBinding(
+			key.WithKeys("shift+right"),
+		),
+		PageUp: key.NewBinding(
+			key.WithKeys("shift+left"),
+		),
+	}
+
+	return &keys
+}
+
+// createTable creates an intractable table which contains information about all of
+// the given instance types
+func createTable(instanceTypes []*instancetypes.Details) table.Model {
+	// calculate and fetch all column data from instance types
+	columnsData := getWideColumnsData(instanceTypes)
+
+	newTable := table.New(*createColumns(columnsData)).
+		WithRows(*createRows(columnsData)).
+		WithKeyMap(*createKeyMap()).
+		WithPageSize(initialDimensionVal).
+		Focused(true).
+		Border(customBorder).
+		WithMaxTotalWidth(initialDimensionVal).
+		WithHorizontalFreezeColumnCount(1).
+		WithBaseStyle(
+			lipgloss.NewStyle().
+				Align((lipgloss.Left)),
+		).
+		HeaderStyle(lipgloss.NewStyle().Align(lipgloss.Center).Bold(true))
+
+	return newTable
+}
+
+// resizeView will change the dimensions of the table in order to accommodate
+// the new window dimensions represented by the given tea.WindowSizeMsg
+func (m tableModel) resizeView(msg tea.WindowSizeMsg) tableModel {
+	// handle width changes
+	m.table = m.table.WithMaxTotalWidth(msg.Width)
+	m.tableWidth = msg.Width
+
+	// handle height changes
+	if headerAndFooterPadding >= msg.Height {
+		// height too short to fit rows
+		m.table = m.table.WithPageSize(0)
+	} else {
+		newRowsPerPage := msg.Height - headerAndFooterPadding
+		m.table = m.table.WithPageSize(newRowsPerPage)
+	}
+
+	return m
+}
+
+// updateFooter updates the page and controls string in the table footer
+func (m tableModel) updateFooter() tableModel {
+	controlsStr := tableControls
+
+	// prevent controls text from wrapping to avoid table misprints
+	pageStr := fmt.Sprintf("Page: %d/%d | ", m.table.CurrentPage(), m.table.MaxPages())
+	if m.tableWidth < len(pageStr)+len(controlsStr) {
+		controlsWidth := m.tableWidth - len(ellipses) - len(pageStr) - 2
+		if controlsWidth < 0 {
+			controlsWidth = 0
+		} else if controlsWidth > len(tableControls) {
+			controlsWidth = len(tableControls)
+		}
+		controlsStr = tableControls[0:controlsWidth] + ellipses
+	}
+
+	renderedControls := lipgloss.NewStyle().Faint(true).Render(controlsStr)
+	footerStr := fmt.Sprintf("%s%s", pageStr, renderedControls)
+	m.table = m.table.WithStaticFooter(footerStr)
+
+	return m
+}
+
+// update updates the state of the tableModel
+func (m tableModel) update(msg tea.Msg) (tableModel, tea.Cmd) {
+	var cmd tea.Cmd
+	m.table, cmd = m.table.Update(msg)
+
+	// update footer
+	m = m.updateFooter()
+
+	return m, cmd
+}
+
+// view returns a string representing the table view
+func (m tableModel) view() string {
+	return m.table.View() + "\n"
+}

--- a/pkg/selector/outputs/verboseView.go
+++ b/pkg/selector/outputs/verboseView.go
@@ -1,0 +1,121 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package outputs
+
+import (
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/instancetypes"
+	"github.com/charmbracelet/bubbles/viewport"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+const (
+	// verbose view formatting
+	outlinePadding = 8
+
+	// controls
+	verboseControls = "Controls: ↑/↓ - up/down • enter - return to table • q - quit"
+)
+
+// verboseModel represents the current state of the verbose view
+type verboseModel struct {
+	// model for verbose output viewport
+	viewport viewport.Model
+
+	instanceTypes []*instancetypes.Details
+
+	// the instance which the verbose output is focused on
+	focusedInstanceName *string
+}
+
+// styling for viewport
+var (
+	titleStyle = func() lipgloss.Style {
+		b := lipgloss.RoundedBorder()
+		b.Right = "├"
+		return lipgloss.NewStyle().BorderStyle(b).Padding(0, 1)
+	}()
+
+	infoStyle = func() lipgloss.Style {
+		b := lipgloss.RoundedBorder()
+		b.Left = "┤"
+		return titleStyle.Copy().BorderStyle(b)
+	}()
+)
+
+// initVerboseModel initializes and returns a new verboseModel based on the given
+// instance type details
+func initVerboseModel(instanceTypes []*instancetypes.Details) *verboseModel {
+	viewportModel := viewport.New(initialDimensionVal, initialDimensionVal)
+	viewportModel.MouseWheelEnabled = true
+
+	return &verboseModel{
+		viewport:      viewportModel,
+		instanceTypes: instanceTypes,
+	}
+}
+
+// resizeView will change the dimensions of the verbose viewport in order to accommodate
+// the new window dimensions represented by the given tea.WindowSizeMsg
+func (m verboseModel) resizeView(msg tea.WindowSizeMsg) verboseModel {
+	// handle width changes
+	m.viewport.Width = msg.Width
+
+	// handle height changes
+	if outlinePadding >= msg.Height {
+		// height too short to fit viewport
+		m.viewport.Height = 0
+	} else {
+		newHeight := msg.Height - outlinePadding
+		m.viewport.Height = newHeight
+	}
+
+	return m
+}
+
+// update updates the state of the verboseModel
+func (m verboseModel) update(msg tea.Msg) (verboseModel, tea.Cmd) {
+	var cmd tea.Cmd
+	m.viewport, cmd = m.viewport.Update(msg)
+	return m, cmd
+}
+
+func (m verboseModel) view() string {
+	outputStr := strings.Builder{}
+
+	// format header for viewport
+	instanceName := titleStyle.Render(*m.focusedInstanceName)
+	line := strings.Repeat("─", int(math.Max(0, float64(m.viewport.Width-lipgloss.Width(instanceName)))))
+	outputStr.WriteString(lipgloss.JoinHorizontal(lipgloss.Center, instanceName, line))
+	outputStr.WriteString("\n")
+
+	outputStr.WriteString(m.viewport.View())
+	outputStr.WriteString("\n")
+
+	// format footer for viewport
+	pagePercentage := infoStyle.Render(fmt.Sprintf("%3.f%%", m.viewport.ScrollPercent()*100))
+	line = strings.Repeat("─", int(math.Max(0, float64(m.viewport.Width-lipgloss.Width(pagePercentage)))))
+	outputStr.WriteString(lipgloss.JoinHorizontal(lipgloss.Center, line, pagePercentage))
+	outputStr.WriteString("\n")
+
+	// controls
+	outputStr.WriteString(lipgloss.NewStyle().Faint(true).Render(verboseControls))
+	outputStr.WriteString("\n")
+
+	return outputStr.String()
+}


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Created an additional view for the `interactive` output option which displays all of the details of a selected instance type in JSON format (uses the `VerboseInstanceTypeOutput` function implemented in `pkg/selector/outputs/outputs.go` to format the instance type). This new view is reached by pressing "enter" on any highlighted row during the `interactive` output mode. The highlighted instance type will then be shown in detail in a horizontally and vertically resizable viewport.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

https://user-images.githubusercontent.com/68402662/182289597-623bb887-12e0-4f05-8127-28d25261e303.mov