### PR TITLE
Interactive table sorting, trimming, and filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,12 @@ t3.medium      2       4          nitro       true         true                 
 t3a.medium     2       4          nitro       true         true                 x86_64        Up to 5 Gigabit      3       0       0              none      -Not Fetched-       $0.01246
 ```
 
+**Interactive Output**
+```
+$ ec2-instance-selector -o interactive
+```
+https://user-images.githubusercontent.com/68402662/184218343-6b236d4a-3fe6-42ae-9fe3-3fd3ee92a4b5.mov
+
 **Sort by memory in ascending order using shorthand**
 ```
 $ ec2-instance-selector -r us-east-1 -o table-wide --max-results 10 --sort-by memory --sort-direction asc

--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -1452,3 +1452,30 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+------
+
+** github.com/sahilm/fuzzy; v0.1.0 --
+https://github.com/sahilm/fuzzy
+
+The MIT License (MIT)
+
+Copyright (c) 2017 Sahil Muthoo
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -129,22 +129,9 @@ const (
 	sortDescending = "descending"
 	sortDesc       = "desc"
 
-	// Sorting Fields
-	spotPrice = "spot-price"
-	odPrice   = "on-demand-price"
+	// Sort filter default
 
-	// JSON field paths
-	instanceNamePath                   = ".InstanceType"
-	vcpuPath                           = ".VCpuInfo.DefaultVCpus"
-	memoryPath                         = ".MemoryInfo.SizeInMiB"
-	gpuMemoryTotalPath                 = ".GpuInfo.TotalGpuMemoryInMiB"
-	networkInterfacesPath              = ".NetworkInfo.MaximumNetworkInterfaces"
-	spotPricePath                      = ".SpotPrice"
-	odPricePath                        = ".OndemandPricePerHour"
-	instanceStoragePath                = ".InstanceStorageInfo.TotalSizeInGB"
-	ebsOptimizedBaselineBandwidthPath  = ".EbsInfo.EbsOptimizedInfo.BaselineBandwidthInMbps"
-	ebsOptimizedBaselineThroughputPath = ".EbsInfo.EbsOptimizedInfo.BaselineThroughputInMBps"
-	ebsOptimizedBaselineIOPSPath       = ".EbsInfo.EbsOptimizedInfo.BaselineIops"
+	instanceNamePath = ".InstanceType"
 )
 
 var (
@@ -181,22 +168,6 @@ Full docs can be found at github.com/aws/amazon-` + binName
 		sortAsc,
 		sortDescending,
 		sortDesc,
-	}
-
-	// map quantity cli flags to json paths for easier cli sorting
-	sortingKeysMap := map[string]string{
-		vcpus:                          vcpuPath,
-		memory:                         memoryPath,
-		gpuMemoryTotal:                 gpuMemoryTotalPath,
-		networkInterfaces:              networkInterfacesPath,
-		spotPrice:                      spotPricePath,
-		odPrice:                        odPricePath,
-		instanceStorage:                instanceStoragePath,
-		ebsOptimizedBaselineBandwidth:  ebsOptimizedBaselineBandwidthPath,
-		ebsOptimizedBaselineThroughput: ebsOptimizedBaselineThroughputPath,
-		ebsOptimizedBaselineIOPS:       ebsOptimizedBaselineIOPSPath,
-		gpus:                           gpus,
-		inferenceAccelerators:          inferenceAccelerators,
 	}
 
 	// Registers flags with specific input types from the cli pkg
@@ -417,11 +388,6 @@ Full docs can be found at github.com/aws/amazon-` + binName
 		} else {
 			log.Println("There were no transformations on the filters to display")
 		}
-	}
-
-	// determine if user used a shorthand for sorting flag
-	if sortFieldShorthandPath, ok := sortingKeysMap[*sortField]; ok {
-		sortField = &sortFieldShorthandPath
 	}
 
 	// fetch instance types without truncating results

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -49,6 +49,9 @@ const (
 	tableWideOutput = "table-wide"
 	oneLine         = "one-line"
 	bubbleTeaOutput = "interactive"
+
+	// Sort filter default
+	instanceNamePath = ".InstanceType"
 )
 
 // Filter Flag Constants
@@ -120,20 +123,6 @@ const (
 	sortBy        = "sort-by"
 )
 
-// Sorting Constants
-const (
-	// Direction
-
-	sortAscending  = "ascending"
-	sortAsc        = "asc"
-	sortDescending = "descending"
-	sortDesc       = "desc"
-
-	// Sort filter default
-
-	instanceNamePath = ".InstanceType"
-)
-
 var (
 	// versionID is overridden at compilation with the version based on the git tag
 	versionID = "dev"
@@ -164,10 +153,10 @@ Full docs can be found at github.com/aws/amazon-` + binName
 	resultsOutputFn := outputs.SimpleInstanceTypeOutput
 
 	cliSortDirections := []string{
-		sortAscending,
-		sortAsc,
-		sortDescending,
-		sortDesc,
+		sorter.SortAscending,
+		sorter.SortAsc,
+		sorter.SortDescending,
+		sorter.SortDesc,
 	}
 
 	// Registers flags with specific input types from the cli pkg
@@ -234,7 +223,7 @@ Full docs can be found at github.com/aws/amazon-` + binName
 	cli.ConfigBoolFlag(verbose, cli.StringMe("v"), nil, "Verbose - will print out full instance specs")
 	cli.ConfigBoolFlag(help, cli.StringMe("h"), nil, "Help")
 	cli.ConfigBoolFlag(version, nil, nil, "Prints CLI version")
-	cli.ConfigStringOptionsFlag(sortDirection, nil, cli.StringMe(sortAscending), fmt.Sprintf("Specify the direction to sort in (%s)", strings.Join(cliSortDirections, ", ")), cliSortDirections)
+	cli.ConfigStringOptionsFlag(sortDirection, nil, cli.StringMe(sorter.SortAscending), fmt.Sprintf("Specify the direction to sort in (%s)", strings.Join(cliSortDirections, ", ")), cliSortDirections)
 	cli.ConfigStringFlag(sortBy, nil, cli.StringMe(instanceNamePath), "Specify the field to sort by. Quantity flags present in this CLI (memory, gpus, etc.) or a JSON path to the appropriate instance type field (Ex: \".MemoryInfo.SizeInMiB\") is acceptable.", nil)
 
 	// Parses the user input with the registered flags and runs type specific validation on the user input

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.18
 require (
 	github.com/aws/aws-sdk-go v1.44.59
 	github.com/blang/semver/v4 v4.0.0
-	github.com/charmbracelet/bubbles v0.11.0
+	github.com/charmbracelet/bubbles v0.13.0
 	github.com/charmbracelet/bubbletea v0.21.0
 	github.com/charmbracelet/lipgloss v0.5.0
 	github.com/evertras/bubble-table v0.14.4
@@ -32,6 +32,7 @@ require (
 	github.com/muesli/cancelreader v0.2.0 // indirect
 	github.com/muesli/reflow v0.3.0 // indirect
 	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/sahilm/fuzzy v0.1.0 // indirect
 	github.com/smartystreets/goconvey v1.6.4 // indirect
 	go.uber.org/atomic v1.4.0 // indirect
 	golang.org/x/sys v0.0.0-20220209214540-3681064d5158 // indirect

--- a/go.sum
+++ b/go.sum
@@ -15,6 +15,8 @@ github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2y
 github.com/cespare/xxhash v1.1.0/go.mod h1:XrSqR1VqqWfGrhpAt58auRo0WTKS1nRRg3ghfAqPWnc=
 github.com/charmbracelet/bubbles v0.11.0 h1:fBLyY0PvJnd56Vlu5L84JJH6f4axhgIJ9P3NET78f0Q=
 github.com/charmbracelet/bubbles v0.11.0/go.mod h1:bbeTiXwPww4M031aGi8UK2HT9RDWoiNibae+1yCMtcc=
+github.com/charmbracelet/bubbles v0.13.0 h1:zP/ROH3wJEBqZWKIsD50ZKKlx3ydLInq3LdD/Nrlb8w=
+github.com/charmbracelet/bubbles v0.13.0/go.mod h1:bbeTiXwPww4M031aGi8UK2HT9RDWoiNibae+1yCMtcc=
 github.com/charmbracelet/bubbletea v0.21.0 h1:f3y+kanzgev5PA916qxmDybSHU3N804uOnKnhRPXTcI=
 github.com/charmbracelet/bubbletea v0.21.0/go.mod h1:GgmJMec61d08zXsOhqRC/AiOx4K4pmz+VIcRIm1FKr4=
 github.com/charmbracelet/harmonica v0.2.0/go.mod h1:KSri/1RMQOZLbw7AHqgcBycp8pgJnQMYYT8QZRqZ1Ao=
@@ -126,6 +128,7 @@ github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
 github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/sahilm/fuzzy v0.1.0 h1:FzWGaw2Opqyu+794ZQ9SYifWv2EIXpwP4q8dY1kDAwI=
 github.com/sahilm/fuzzy v0.1.0/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=

--- a/pkg/selector/outputs/bubbletea.go
+++ b/pkg/selector/outputs/bubbletea.go
@@ -76,7 +76,28 @@ func (m BubbleTeaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		// don't listen for input if currently typing into text field
-		if m.tableModel.filterTextInput.Focused() || m.sortingModel.sortTextInput.Focused() {
+		if m.tableModel.filterTextInput.Focused() {
+			break
+		} else if m.sortingModel.sortTextInput.Focused() {
+			// see if we should sort and switch states to table
+			if m.currentState == stateSorting && msg.String() == "enter" {
+				jsonPath := m.sortingModel.sortTextInput.Value()
+
+				// TODO: figure out how to get direction
+				sortDirection := "asc"
+
+				var err error
+				m.tableModel, err = m.tableModel.sortTable(jsonPath, sortDirection)
+				if err != nil {
+					m.sortingModel.sortTextInput.SetValue(jsonPathError)
+					break
+				}
+
+				m.currentState = stateTable
+
+				m.sortingModel.sortTextInput.Blur()
+			}
+
 			break
 		}
 

--- a/pkg/selector/outputs/bubbletea.go
+++ b/pkg/selector/outputs/bubbletea.go
@@ -81,12 +81,12 @@ func (m BubbleTeaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 					break
 				}
 
-				// switch from table state to verbose state
-				m.currentState = stateVerbose
-
 				// get focused instance type
 				focusedRow := m.tableModel.table.HighlightedRow()
-				focusedInstance := focusedRow.Data[metaDataKey].(*instancetypes.Details)
+				focusedInstance, ok := focusedRow.Data[metaDataKey].(*instancetypes.Details)
+				if !ok {
+					break
+				}
 
 				// set content of view
 				m.verboseModel.focusedInstanceName = focusedInstance.InstanceType
@@ -94,6 +94,9 @@ func (m BubbleTeaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 				// move viewport to top of printout
 				m.verboseModel.viewport.SetYOffset(0)
+
+				// switch from table state to verbose state
+				m.currentState = stateVerbose
 			case stateVerbose:
 				// switch from verbose state to table state
 				m.currentState = stateTable

--- a/pkg/selector/outputs/bubbletea.go
+++ b/pkg/selector/outputs/bubbletea.go
@@ -22,6 +22,8 @@ import (
 const (
 	// can't get terminal dimensions on startup, so use this
 	initialDimensionVal = 30
+
+	metaDataKey = "instance type"
 )
 
 const (
@@ -83,8 +85,8 @@ func (m BubbleTeaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.currentState = stateVerbose
 
 				// get focused instance type
-				rowIndex := m.tableModel.table.GetHighlightedRowIndex()
-				focusedInstance := m.verboseModel.instanceTypes[rowIndex]
+				focusedRow := m.tableModel.table.HighlightedRow()
+				focusedInstance := focusedRow.Data[metaDataKey].(*instancetypes.Details)
 
 				// set content of view
 				m.verboseModel.focusedInstanceName = focusedInstance.InstanceType

--- a/pkg/selector/outputs/bubbletea.go
+++ b/pkg/selector/outputs/bubbletea.go
@@ -83,8 +83,10 @@ func (m BubbleTeaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.currentState == stateSorting && msg.String() == "enter" {
 				jsonPath := m.sortingModel.sortTextInput.Value()
 
-				// TODO: figure out how to get direction
 				sortDirection := "asc"
+				if m.sortingModel.isDescending {
+					sortDirection = "desc"
+				}
 
 				var err error
 				m.tableModel, err = m.tableModel.sortTable(jsonPath, sortDirection)
@@ -138,8 +140,10 @@ func (m BubbleTeaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.currentState == stateSorting {
 				sortFilter := string(m.sortingModel.shorthandList.SelectedItem().(item))
 
-				// TODO: figure out how to get sort direction
 				sortDirection := "asc"
+				if m.sortingModel.isDescending {
+					sortDirection = "desc"
+				}
 
 				var err error
 				m.tableModel, err = m.tableModel.sortTable(sortFilter, sortDirection)

--- a/pkg/selector/outputs/bubbletea.go
+++ b/pkg/selector/outputs/bubbletea.go
@@ -134,7 +134,24 @@ func (m BubbleTeaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.currentState = stateSorting
 			}
 		case "enter":
-			// TODO: sorting select
+			// sort and switch states to table
+			if m.currentState == stateSorting {
+				sortFilter := string(m.sortingModel.shorthandList.SelectedItem().(item))
+
+				// TODO: figure out how to get sort direction
+				sortDirection := "asc"
+
+				var err error
+				m.tableModel, err = m.tableModel.sortTable(sortFilter, sortDirection)
+				if err != nil {
+					m.sortingModel.sortTextInput.SetValue("INVALID SHORTHAND VALUE")
+					break
+				}
+
+				m.currentState = stateTable
+
+				m.sortingModel.sortTextInput.Blur()
+			}
 		case "esc":
 			// switch from sorting state to table state
 			if m.currentState == stateSorting {

--- a/pkg/selector/outputs/bubbletea.go
+++ b/pkg/selector/outputs/bubbletea.go
@@ -24,7 +24,8 @@ const (
 	// can't get terminal dimensions on startup, so use this
 	initialDimensionVal = 30
 
-	metaDataKey = "instance type"
+	instanceTypeKey = "instance type"
+	selectedKey     = "selected"
 )
 
 const (
@@ -88,7 +89,7 @@ func (m BubbleTeaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			case stateTable:
 				// get focused instance type
 				focusedRow := m.tableModel.table.HighlightedRow()
-				focusedInstance, ok := focusedRow.Data[metaDataKey].(*instancetypes.Details)
+				focusedInstance, ok := focusedRow.Data[instanceTypeKey].(*instancetypes.Details)
 				if !ok {
 					break
 				}

--- a/pkg/selector/outputs/bubbletea.go
+++ b/pkg/selector/outputs/bubbletea.go
@@ -62,7 +62,7 @@ func NewBubbleTeaModel(instanceTypes []*instancetypes.Details) BubbleTeaModel {
 		currentState: stateTable,
 		tableModel:   *initTableModel(instanceTypes),
 		verboseModel: *initVerboseModel(instanceTypes),
-		sortingModel: *initSortingView(instanceTypes),
+		sortingModel: *initSortingModel(instanceTypes),
 	}
 }
 

--- a/pkg/selector/outputs/bubbletea.go
+++ b/pkg/selector/outputs/bubbletea.go
@@ -65,6 +65,11 @@ func (m BubbleTeaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		// check for quit or change in state
 		switch msg.String() {
 		case "ctrl+c", "q":
+			// don't change state if using text input
+			if m.tableModel.filterTextInput.Focused() {
+				break
+			}
+
 			return m, tea.Quit
 		case "e":
 			switch m.currentState {

--- a/pkg/selector/outputs/bubbletea.go
+++ b/pkg/selector/outputs/bubbletea.go
@@ -66,9 +66,14 @@ func (m BubbleTeaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.String() {
 		case "ctrl+c", "q":
 			return m, tea.Quit
-		case "enter":
+		case "e":
 			switch m.currentState {
 			case stateTable:
+				// don't change state if using text input
+				if m.tableModel.filterTextInput.Focused() {
+					break
+				}
+
 				// switch from table state to verbose state
 				m.currentState = stateVerbose
 

--- a/pkg/selector/outputs/bubbletea.go
+++ b/pkg/selector/outputs/bubbletea.go
@@ -15,6 +15,7 @@ package outputs
 
 import (
 	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/instancetypes"
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/sorter"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/muesli/termenv"
@@ -83,9 +84,9 @@ func (m BubbleTeaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.currentState == stateSorting && msg.String() == "enter" {
 				jsonPath := m.sortingModel.sortTextInput.Value()
 
-				sortDirection := "asc"
+				sortDirection := sorter.SortAscending
 				if m.sortingModel.isDescending {
-					sortDirection = "desc"
+					sortDirection = sorter.SortDescending
 				}
 
 				var err error
@@ -140,9 +141,9 @@ func (m BubbleTeaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			if m.currentState == stateSorting {
 				sortFilter := string(m.sortingModel.shorthandList.SelectedItem().(item))
 
-				sortDirection := "asc"
+				sortDirection := sorter.SortAscending
 				if m.sortingModel.isDescending {
-					sortDirection = "desc"
+					sortDirection = sorter.SortDescending
 				}
 
 				var err error

--- a/pkg/selector/outputs/bubbletea.go
+++ b/pkg/selector/outputs/bubbletea.go
@@ -109,8 +109,8 @@ func (m BubbleTeaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		case "ctrl+c", "q":
 			return m, tea.Quit
 		case "e":
-			switch m.currentState {
-			case stateTable:
+			// switch from table state to verbose state
+			if m.currentState == stateTable {
 				// get focused instance type
 				focusedRow := m.tableModel.table.HighlightedRow()
 				focusedInstance, ok := focusedRow.Data[instanceTypeKey].(*instancetypes.Details)
@@ -127,9 +127,6 @@ func (m BubbleTeaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 				// switch from table state to verbose state
 				m.currentState = stateVerbose
-			case stateVerbose:
-				// switch from verbose state to table state
-				m.currentState = stateTable
 			}
 		case "s":
 			// switch from table view to sorting view
@@ -158,8 +155,8 @@ func (m BubbleTeaModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				m.sortingModel.sortTextInput.Blur()
 			}
 		case "esc":
-			// switch from sorting state to table state
-			if m.currentState == stateSorting {
+			// switch from sorting state or verbose state to table state
+			if m.currentState == stateSorting || m.currentState == stateVerbose {
 				m.currentState = stateTable
 			}
 		}

--- a/pkg/selector/outputs/sortingView.go
+++ b/pkg/selector/outputs/sortingView.go
@@ -1,0 +1,263 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package outputs
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/instancetypes"
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/sorter"
+	"github.com/charmbracelet/bubbles/key"
+	"github.com/charmbracelet/bubbles/list"
+	"github.com/charmbracelet/bubbles/textinput"
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/evertras/bubble-table/table"
+)
+
+const (
+	// formatting
+	sortingTitlePadding  = 3
+	sortingFooterPadding = 2
+
+	// shorthand flags
+	gpus                           = "gpus"
+	inferenceAccelerators          = "inference-accelerators"
+	vcpus                          = "vcpus"
+	memory                         = "memory"
+	gpuMemoryTotal                 = "gpu-memory-total"
+	networkInterfaces              = "network-interfaces"
+	spotPrice                      = "spot-price"
+	odPrice                        = "on-demand-price"
+	instanceStorage                = "instance-storage"
+	ebsOptimizedBaselineBandwidth  = "ebs-optimized-baseline-bandwidth"
+	ebsOptimizedBaselineThroughput = "ebs-optimized-baseline-throughput"
+	ebsOptimizedBaselineIOPS       = "ebs-optimized-baseline-iops"
+
+	// controls
+	sortingListControls = "Controls: ↑/↓ - up/down • esc - return to table • enter - select filter • q - quit"
+	sortingTextControls = "Controls: ↑/↓ - up/down • enter - enter json path"
+)
+
+// sortingModel holds the state for the sorting view
+type sortingModel struct {
+	// list which holds the available shorting shorthands
+	shorthandList list.Model
+
+	// text input for json paths
+	sortTextInput textinput.Model
+
+	instanceTypes []*instancetypes.Details
+}
+
+// list format styles
+var (
+	listTitleStyle    = lipgloss.NewStyle().MarginLeft(2)
+	listItemStyle     = lipgloss.NewStyle().PaddingLeft(4)
+	selectedItemStyle = lipgloss.NewStyle().PaddingLeft(2).Foreground(lipgloss.Color("170"))
+)
+
+// implement Item interface for list
+type item string
+
+func (i item) FilterValue() string { return "" }
+func (i item) Title() string       { return string(i) }
+func (i item) Description() string { return "" }
+
+// implement ItemDelegate for list
+type itemDelegate struct{}
+
+func (d itemDelegate) Height() int                               { return 1 }
+func (d itemDelegate) Spacing() int                              { return 0 }
+func (d itemDelegate) Update(msg tea.Msg, m *list.Model) tea.Cmd { return nil }
+func (d itemDelegate) Render(w io.Writer, m list.Model, index int, listItem list.Item) {
+	i, ok := listItem.(item)
+	if !ok {
+		return
+	}
+
+	str := fmt.Sprintf("%d. %s", index+1, i)
+
+	fn := listItemStyle.Render
+	if index == m.Index() {
+		fn = func(s string) string {
+			return selectedItemStyle.Render("> " + s)
+		}
+	}
+
+	fmt.Fprintf(w, fn(str))
+}
+
+// initSortingView initializes and returns a new tableModel based on the given
+// instance type details
+func initSortingView(instanceTypes []*instancetypes.Details) *sortingModel {
+	shorthandList := list.New(*createListItems(), itemDelegate{}, initialDimensionVal, initialDimensionVal)
+	shorthandList.Title = "Select sorting filter:"
+	shorthandList.Styles.Title = listTitleStyle
+	shorthandList.SetFilteringEnabled(false)
+	shorthandList.SetShowStatusBar(false)
+	shorthandList.SetShowHelp(false)
+	shorthandList.SetShowPagination(false)
+	shorthandList.KeyMap = createListKeyMap()
+
+	sortTextInput := textinput.New()
+	sortTextInput.Prompt = "JSON Path: "
+	sortTextInput.PromptStyle = lipgloss.NewStyle().Bold(true)
+
+	return &sortingModel{
+		shorthandList: shorthandList,
+		sortTextInput: sortTextInput,
+		instanceTypes: instanceTypes,
+	}
+}
+
+// createListKeyMap creates a KeyMap with the controls for the shorthand list
+func createListKeyMap() list.KeyMap {
+	return list.KeyMap{
+		CursorDown: key.NewBinding(
+			key.WithKeys("down"),
+		),
+		CursorUp: key.NewBinding(
+			key.WithKeys("up"),
+		),
+	}
+}
+
+// createListItems creates a list item for shorthand sorting flag
+func createListItems() *[]list.Item {
+	shorthandFlags := []string{
+		gpus,
+		inferenceAccelerators,
+		vcpus,
+		memory,
+		gpuMemoryTotal,
+		networkInterfaces,
+		spotPrice,
+		odPrice,
+		instanceStorage,
+		ebsOptimizedBaselineBandwidth,
+		ebsOptimizedBaselineThroughput,
+		ebsOptimizedBaselineIOPS,
+	}
+
+	items := []list.Item{}
+
+	for _, flag := range shorthandFlags {
+		items = append(items, item(flag))
+	}
+
+	return &items
+}
+
+// resizeSortingView will change the dimensions of the sorting view
+// in order to accommodate the new window dimensions represented by
+// the given tea.WindowSizeMsg
+func (m sortingModel) resizeView(msg tea.WindowSizeMsg) sortingModel {
+	shorthandList := &m.shorthandList
+	shorthandList.SetWidth(msg.Width)
+	// ensure that text input is right below last option
+	if msg.Height >= len(shorthandList.Items())+sortingTitlePadding+sortingFooterPadding {
+		shorthandList.SetHeight(len(shorthandList.Items()) + sortingTitlePadding)
+	} else if msg.Height-sortingFooterPadding > 0 {
+		shorthandList.SetHeight(msg.Height - sortingFooterPadding)
+	} else {
+		shorthandList.SetHeight(1)
+	}
+
+	// ensure cursor of list is still hidden after resize
+	if m.sortTextInput.Focused() {
+		shorthandList.Select(len(m.shorthandList.Items()))
+	}
+
+	m.shorthandList = *shorthandList
+
+	return m
+}
+
+// sortTable sorts the table based on the sorting direction and sorting filter
+// TODO: maybe move this to tableView and then call it in bubble tea when change of state occurs
+func (m sortingModel) sortTable(model BubbleTeaModel, sortFilter string, sortDirection string) (table.Model, error) {
+	instanceTypes, err := sorter.Sort(m.instanceTypes, sortFilter, sortDirection)
+	if err != nil {
+		return model.tableModel.table, err
+	}
+
+	// TODO: maybe ensure dimensions are the same as old table before returning
+	// ensure truncation still occurs by maybe storing selected items and then doing the truncation process here?
+	// ensure filtering is reapplied
+
+	// TODO: To ensure that selected items remain after sorting, perhaps map instancetype to rows. That way
+	// we can quickly sort rows based on the returned sorted instance types. This way we can maybe also avoid
+	// storing instance types in the sortingModel struct because we can have a loop that not only does the mapping
+	// but also gives us a list of instance types from the visible rows
+
+	return createTable(instanceTypes), nil
+}
+
+// update updates the state of the sortingModel
+func (m sortingModel) update(msg tea.Msg) (sortingModel, tea.Cmd) {
+	var cmd tea.Cmd
+	var cmds []tea.Cmd
+
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "down":
+			if m.shorthandList.Index() == len(m.shorthandList.Items())-1 {
+				// focus text input and hide cursor in shorthand list
+				m.shorthandList.Select(len(m.shorthandList.Items()))
+				m.sortTextInput.Focus()
+			}
+		case "up":
+			if m.sortTextInput.Focused() {
+				// go back to list from text input
+				m.shorthandList.Select(len(m.shorthandList.Items()))
+				m.sortTextInput.Blur()
+			}
+		}
+
+		if m.sortTextInput.Focused() {
+			m.sortTextInput, cmd = m.sortTextInput.Update(msg)
+			cmds = append(cmds, cmd)
+		}
+	}
+
+	if !m.sortTextInput.Focused() {
+		m.shorthandList, cmd = m.shorthandList.Update(msg)
+		cmds = append(cmds, cmd)
+	}
+
+	return m, tea.Batch(cmds...)
+}
+
+// view returns a string representing the sorting view
+func (m sortingModel) view() string {
+	outputStr := strings.Builder{}
+
+	outputStr.WriteString(m.shorthandList.View())
+	outputStr.WriteString("\n")
+
+	outputStr.WriteString(m.sortTextInput.View())
+	outputStr.WriteString("\n")
+
+	if m.sortTextInput.Focused() {
+		outputStr.WriteString(controlsStyle.Render(sortingTextControls))
+	} else {
+		outputStr.WriteString(controlsStyle.Render(sortingListControls))
+	}
+
+	return outputStr.String()
+}

--- a/pkg/selector/outputs/sortingView.go
+++ b/pkg/selector/outputs/sortingView.go
@@ -236,8 +236,7 @@ func (m sortingModel) view() string {
 	} else {
 		outputStr.WriteString(ascendingStyle.Render(ascendingText))
 	}
-	outputStr.WriteString("\n")
-	outputStr.WriteString("\n")
+	outputStr.WriteString("\n\n")
 
 	// draw list
 	outputStr.WriteString(m.shorthandList.View())

--- a/pkg/selector/outputs/sortingView.go
+++ b/pkg/selector/outputs/sortingView.go
@@ -19,13 +19,11 @@ import (
 	"strings"
 
 	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/instancetypes"
-	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/sorter"
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/evertras/bubble-table/table"
 )
 
 const (
@@ -185,26 +183,6 @@ func (m sortingModel) resizeView(msg tea.WindowSizeMsg) sortingModel {
 	m.shorthandList = *shorthandList
 
 	return m
-}
-
-// sortTable sorts the table based on the sorting direction and sorting filter
-// TODO: maybe move this to tableView and then call it in bubble tea when change of state occurs
-func (m sortingModel) sortTable(model BubbleTeaModel, sortFilter string, sortDirection string) (table.Model, error) {
-	instanceTypes, err := sorter.Sort(m.instanceTypes, sortFilter, sortDirection)
-	if err != nil {
-		return model.tableModel.table, err
-	}
-
-	// TODO: maybe ensure dimensions are the same as old table before returning
-	// ensure truncation still occurs by maybe storing selected items and then doing the truncation process here?
-	// ensure filtering is reapplied
-
-	// TODO: To ensure that selected items remain after sorting, perhaps map instancetype to rows. That way
-	// we can quickly sort rows based on the returned sorted instance types. This way we can maybe also avoid
-	// storing instance types in the sortingModel struct because we can have a loop that not only does the mapping
-	// but also gives us a list of instance types from the visible rows
-
-	return createTable(instanceTypes), nil
 }
 
 // update updates the state of the sortingModel

--- a/pkg/selector/outputs/sortingView.go
+++ b/pkg/selector/outputs/sortingView.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/instancetypes"
+	"github.com/aws/amazon-ec2-instance-selector/v2/pkg/sorter"
 	"github.com/charmbracelet/bubbles/key"
 	"github.com/charmbracelet/bubbles/list"
 	"github.com/charmbracelet/bubbles/textinput"
@@ -31,20 +32,6 @@ const (
 	sortDirectionPadding = 2
 	sortingTitlePadding  = 3
 	sortingFooterPadding = 2
-
-	// shorthand flags
-	gpus                           = "gpus"
-	inferenceAccelerators          = "inference-accelerators"
-	vcpus                          = "vcpus"
-	memory                         = "memory"
-	gpuMemoryTotal                 = "gpu-memory-total"
-	networkInterfaces              = "network-interfaces"
-	spotPrice                      = "spot-price"
-	odPrice                        = "on-demand-price"
-	instanceStorage                = "instance-storage"
-	ebsOptimizedBaselineBandwidth  = "ebs-optimized-baseline-bandwidth"
-	ebsOptimizedBaselineThroughput = "ebs-optimized-baseline-throughput"
-	ebsOptimizedBaselineIOPS       = "ebs-optimized-baseline-iops"
 
 	// controls
 	sortingListControls = "Controls: ↑/↓ - up/down • enter - select filter • tab - toggle direction • esc - return to table • q - quit"
@@ -151,18 +138,18 @@ func createListKeyMap() list.KeyMap {
 // createListItems creates a list item for shorthand sorting flag
 func createListItems() *[]list.Item {
 	shorthandFlags := []string{
-		gpus,
-		inferenceAccelerators,
-		vcpus,
-		memory,
-		gpuMemoryTotal,
-		networkInterfaces,
-		spotPrice,
-		odPrice,
-		instanceStorage,
-		ebsOptimizedBaselineBandwidth,
-		ebsOptimizedBaselineThroughput,
-		ebsOptimizedBaselineIOPS,
+		sorter.GPUCountField,
+		sorter.InferenceAcceleratorsField,
+		sorter.VCPUs,
+		sorter.Memory,
+		sorter.GPUMemoryTotal,
+		sorter.NetworkInterfaces,
+		sorter.SpotPrice,
+		sorter.ODPrice,
+		sorter.InstanceStorage,
+		sorter.EBSOptimizedBaselineBandwidth,
+		sorter.EBSOptimizedBaselineThroughput,
+		sorter.EBSOptimizedBaselineIOPS,
 	}
 
 	items := []list.Item{}

--- a/pkg/selector/outputs/sortingView.go
+++ b/pkg/selector/outputs/sortingView.go
@@ -99,9 +99,9 @@ func (d itemDelegate) Render(w io.Writer, m list.Model, index int, listItem list
 	fmt.Fprintf(w, fn(str))
 }
 
-// initSortingView initializes and returns a new tableModel based on the given
+// initSortingModel initializes and returns a new tableModel based on the given
 // instance type details
-func initSortingView(instanceTypes []*instancetypes.Details) *sortingModel {
+func initSortingModel(instanceTypes []*instancetypes.Details) *sortingModel {
 	shorthandList := list.New(*createListItems(), itemDelegate{}, initialDimensionVal, initialDimensionVal)
 	shorthandList.Title = "Select sorting filter:"
 	shorthandList.Styles.Title = listTitleStyle

--- a/pkg/selector/outputs/tableView.go
+++ b/pkg/selector/outputs/tableView.go
@@ -88,11 +88,11 @@ func createFilterTextInput() textinput.Model {
 }
 
 // createRows creates a row for each instance type in the passed in list
-func createRows(columnsData []*wideColumnsData) *[]table.Row {
+func createRows(columnsData []*wideColumnsData, instanceTypes []*instancetypes.Details) *[]table.Row {
 	rows := []table.Row{}
 
 	// create a row for each instance type
-	for _, data := range columnsData {
+	for i, data := range columnsData {
 		rowData := table.RowData{}
 
 		// create a new row by iterating through the column data
@@ -105,6 +105,9 @@ func createRows(columnsData []*wideColumnsData) *[]table.Row {
 			colValue := structValue.Field(i)
 			rowData[columnName] = getUnderlyingValue(colValue)
 		}
+
+		// add instance type as metaData
+		rowData[metaDataKey] = instanceTypes[i]
 
 		newRow := table.NewRow(rowData)
 
@@ -197,7 +200,7 @@ func createTable(instanceTypes []*instancetypes.Details) table.Model {
 	columnsData := getWideColumnsData(instanceTypes)
 
 	newTable := table.New(*createColumns(columnsData)).
-		WithRows(*createRows(columnsData)).
+		WithRows(*createRows(columnsData, instanceTypes)).
 		WithKeyMap(*createKeyMap()).
 		WithPageSize(initialDimensionVal).
 		Focused(true).

--- a/pkg/selector/outputs/tableView.go
+++ b/pkg/selector/outputs/tableView.go
@@ -436,7 +436,6 @@ func (m tableModel) getInstanceTypeFromRows() ([]*instancetypes.Details, map[str
 func (m tableModel) getUnfilteredRows() []table.Row {
 	m.table = m.table.Filtered(false)
 	rows := m.table.GetVisibleRows()
-	m.table = m.table.Filtered(true)
 
 	return rows
 }

--- a/pkg/selector/outputs/tableView.go
+++ b/pkg/selector/outputs/tableView.go
@@ -74,8 +74,17 @@ func initTableModel(instanceTypes []*instancetypes.Details) *tableModel {
 	return &tableModel{
 		table:           createTable(instanceTypes),
 		tableWidth:      initialDimensionVal,
-		filterTextInput: textinput.New(),
+		filterTextInput: createFilterTextInput(),
 	}
+}
+
+// createFilterTextInput creates and styles a text input for filtering
+func createFilterTextInput() textinput.Model {
+	filterTextInput := textinput.New()
+	filterTextInput.Prompt = "Filter: "
+	filterTextInput.PromptStyle = lipgloss.NewStyle().Bold(true)
+
+	return filterTextInput
 }
 
 // createRows creates a row for each instance type in the passed in list

--- a/pkg/selector/outputs/verboseView.go
+++ b/pkg/selector/outputs/verboseView.go
@@ -29,7 +29,7 @@ const (
 	outlinePadding = 8
 
 	// controls
-	verboseControls = "Controls: ↑/↓ - up/down • e - return to table • q - quit"
+	verboseControls = "Controls: ↑/↓ - up/down • esc - return to table • q - quit"
 )
 
 // verboseModel represents the current state of the verbose view

--- a/pkg/selector/outputs/verboseView.go
+++ b/pkg/selector/outputs/verboseView.go
@@ -111,7 +111,7 @@ func (m verboseModel) view() string {
 	outputStr.WriteString("\n")
 
 	// controls
-	outputStr.WriteString(lipgloss.NewStyle().Faint(true).Render(verboseControls))
+	outputStr.WriteString(controlsStyle.Render(verboseControls))
 	outputStr.WriteString("\n")
 
 	return outputStr.String()

--- a/pkg/selector/outputs/verboseView.go
+++ b/pkg/selector/outputs/verboseView.go
@@ -37,8 +37,6 @@ type verboseModel struct {
 	// model for verbose output viewport
 	viewport viewport.Model
 
-	instanceTypes []*instancetypes.Details
-
 	// the instance which the verbose output is focused on
 	focusedInstanceName *string
 }
@@ -65,8 +63,7 @@ func initVerboseModel(instanceTypes []*instancetypes.Details) *verboseModel {
 	viewportModel.MouseWheelEnabled = true
 
 	return &verboseModel{
-		viewport:      viewportModel,
-		instanceTypes: instanceTypes,
+		viewport: viewportModel,
 	}
 }
 

--- a/pkg/selector/outputs/verboseView.go
+++ b/pkg/selector/outputs/verboseView.go
@@ -29,7 +29,7 @@ const (
 	outlinePadding = 8
 
 	// controls
-	verboseControls = "Controls: ↑/↓ - up/down • enter - return to table • q - quit"
+	verboseControls = "Controls: ↑/↓ - up/down • e - return to table • q - quit"
 )
 
 // verboseModel represents the current state of the verbose view

--- a/pkg/sorter/sorter.go
+++ b/pkg/sorter/sorter.go
@@ -28,29 +28,29 @@ import (
 const (
 	// Sort direction
 
-	sortAscending  = "ascending"
-	sortAsc        = "asc"
-	sortDescending = "descending"
-	sortDesc       = "desc"
+	SortAscending  = "ascending"
+	SortAsc        = "asc"
+	SortDescending = "descending"
+	SortDesc       = "desc"
 
 	// Not all fields can be reached through a json path (Ex: gpu count)
 	// so we have special flags for such cases.
 
-	gpuCountField              = "gpus"
-	inferenceAcceleratorsField = "inference-accelerators"
+	GPUCountField              = "gpus"
+	InferenceAcceleratorsField = "inference-accelerators"
 
 	// shorthand flags
 
-	vcpus                          = "vcpus"
-	memory                         = "memory"
-	gpuMemoryTotal                 = "gpu-memory-total"
-	networkInterfaces              = "network-interfaces"
-	spotPrice                      = "spot-price"
-	odPrice                        = "on-demand-price"
-	instanceStorage                = "instance-storage"
-	ebsOptimizedBaselineBandwidth  = "ebs-optimized-baseline-bandwidth"
-	ebsOptimizedBaselineThroughput = "ebs-optimized-baseline-throughput"
-	ebsOptimizedBaselineIOPS       = "ebs-optimized-baseline-iops"
+	VCPUs                          = "vcpus"
+	Memory                         = "memory"
+	GPUMemoryTotal                 = "gpu-memory-total"
+	NetworkInterfaces              = "network-interfaces"
+	SpotPrice                      = "spot-price"
+	ODPrice                        = "on-demand-price"
+	InstanceStorage                = "instance-storage"
+	EBSOptimizedBaselineBandwidth  = "ebs-optimized-baseline-bandwidth"
+	EBSOptimizedBaselineThroughput = "ebs-optimized-baseline-throughput"
+	EBSOptimizedBaselineIOPS       = "ebs-optimized-baseline-iops"
 
 	// JSON field paths for shorthand flags
 
@@ -91,16 +91,16 @@ type sorter struct {
 // sortDirection represents the direction to sort in. Valid options: "ascending", "asc", "descending", "desc".
 func Sort(instanceTypes []*instancetypes.Details, sortField string, sortDirection string) ([]*instancetypes.Details, error) {
 	sortingKeysMap := map[string]string{
-		vcpus:                          vcpuPath,
-		memory:                         memoryPath,
-		gpuMemoryTotal:                 gpuMemoryTotalPath,
-		networkInterfaces:              networkInterfacesPath,
-		spotPrice:                      spotPricePath,
-		odPrice:                        odPricePath,
-		instanceStorage:                instanceStoragePath,
-		ebsOptimizedBaselineBandwidth:  ebsOptimizedBaselineBandwidthPath,
-		ebsOptimizedBaselineThroughput: ebsOptimizedBaselineThroughputPath,
-		ebsOptimizedBaselineIOPS:       ebsOptimizedBaselineIOPSPath,
+		VCPUs:                          vcpuPath,
+		Memory:                         memoryPath,
+		GPUMemoryTotal:                 gpuMemoryTotalPath,
+		NetworkInterfaces:              networkInterfacesPath,
+		SpotPrice:                      spotPricePath,
+		ODPrice:                        odPricePath,
+		InstanceStorage:                instanceStoragePath,
+		EBSOptimizedBaselineBandwidth:  ebsOptimizedBaselineBandwidthPath,
+		EBSOptimizedBaselineThroughput: ebsOptimizedBaselineThroughputPath,
+		EBSOptimizedBaselineIOPS:       ebsOptimizedBaselineIOPSPath,
 	}
 
 	// determine if user used a shorthand for sorting flag
@@ -130,12 +130,12 @@ func Sort(instanceTypes []*instancetypes.Details, sortField string, sortDirectio
 func newSorter(instanceTypes []*instancetypes.Details, sortField string, sortDirection string) (*sorter, error) {
 	var isDescending bool
 	switch sortDirection {
-	case sortDescending, sortDesc:
+	case SortDescending, SortDesc:
 		isDescending = true
-	case sortAscending, sortAsc:
+	case SortAscending, SortAsc:
 		isDescending = false
 	default:
-		return nil, fmt.Errorf("invalid sort direction: %s (valid options: %s, %s, %s, %s)", sortDirection, sortAscending, sortAsc, sortDescending, sortDesc)
+		return nil, fmt.Errorf("invalid sort direction: %s (valid options: %s, %s, %s, %s)", sortDirection, SortAscending, SortAsc, SortDescending, SortDesc)
 	}
 
 	sortField = formatSortField(sortField)
@@ -163,7 +163,7 @@ func newSorter(instanceTypes []*instancetypes.Details, sortField string, sortDir
 // matches one of the special flags.
 func formatSortField(sortField string) string {
 	// check to see if the sorting field matched one of the special exceptions
-	if sortField == gpuCountField || sortField == inferenceAcceleratorsField {
+	if sortField == GPUCountField || sortField == InferenceAcceleratorsField {
 		return sortField
 	}
 
@@ -176,13 +176,13 @@ func newSorterNode(instanceType *instancetypes.Details, sortField string) (*sort
 	// some important fields (such as gpu count) can not be accessed directly in the instancetypes.Details
 	// struct, so we have special hard-coded flags to handle such cases
 	switch sortField {
-	case gpuCountField:
+	case GPUCountField:
 		gpuCount := getTotalGpusCount(instanceType)
 		return &sorterNode{
 			instanceType: instanceType,
 			fieldValue:   reflect.ValueOf(gpuCount),
 		}, nil
-	case inferenceAcceleratorsField:
+	case InferenceAcceleratorsField:
 		acceleratorsCount := getTotalAcceleratorsCount(instanceType)
 		return &sorterNode{
 			instanceType: instanceType,

--- a/pkg/sorter/sorter.go
+++ b/pkg/sorter/sorter.go
@@ -38,6 +38,33 @@ const (
 
 	gpuCountField              = "gpus"
 	inferenceAcceleratorsField = "inference-accelerators"
+
+	// shorthand flags
+
+	vcpus                          = "vcpus"
+	memory                         = "memory"
+	gpuMemoryTotal                 = "gpu-memory-total"
+	networkInterfaces              = "network-interfaces"
+	spotPrice                      = "spot-price"
+	odPrice                        = "on-demand-price"
+	instanceStorage                = "instance-storage"
+	ebsOptimizedBaselineBandwidth  = "ebs-optimized-baseline-bandwidth"
+	ebsOptimizedBaselineThroughput = "ebs-optimized-baseline-throughput"
+	ebsOptimizedBaselineIOPS       = "ebs-optimized-baseline-iops"
+
+	// JSON field paths for shorthand flags
+
+	instanceNamePath                   = ".InstanceType"
+	vcpuPath                           = ".VCpuInfo.DefaultVCpus"
+	memoryPath                         = ".MemoryInfo.SizeInMiB"
+	gpuMemoryTotalPath                 = ".GpuInfo.TotalGpuMemoryInMiB"
+	networkInterfacesPath              = ".NetworkInfo.MaximumNetworkInterfaces"
+	spotPricePath                      = ".SpotPrice"
+	odPricePath                        = ".OndemandPricePerHour"
+	instanceStoragePath                = ".InstanceStorageInfo.TotalSizeInGB"
+	ebsOptimizedBaselineBandwidthPath  = ".EbsInfo.EbsOptimizedInfo.BaselineBandwidthInMbps"
+	ebsOptimizedBaselineThroughputPath = ".EbsInfo.EbsOptimizedInfo.BaselineThroughputInMBps"
+	ebsOptimizedBaselineIOPSPath       = ".EbsInfo.EbsOptimizedInfo.BaselineIops"
 )
 
 // sorterNode represents a sortable instance type which holds the value
@@ -58,10 +85,29 @@ type sorter struct {
 // Sort sorts the given instance types by the given field in the given direction
 //
 // sortField is a json path to a field in the instancetypes.Details struct which represents
-// the field to sort instance types by (Ex: ".MemoryInfo.SizeInMiB").
+// the field to sort instance types by (Ex: ".MemoryInfo.SizeInMiB"). Quantity flags present
+// in the CLI (memory, gpus, etc.) are also accepted.
 //
 // sortDirection represents the direction to sort in. Valid options: "ascending", "asc", "descending", "desc".
 func Sort(instanceTypes []*instancetypes.Details, sortField string, sortDirection string) ([]*instancetypes.Details, error) {
+	sortingKeysMap := map[string]string{
+		vcpus:                          vcpuPath,
+		memory:                         memoryPath,
+		gpuMemoryTotal:                 gpuMemoryTotalPath,
+		networkInterfaces:              networkInterfacesPath,
+		spotPrice:                      spotPricePath,
+		odPrice:                        odPricePath,
+		instanceStorage:                instanceStoragePath,
+		ebsOptimizedBaselineBandwidth:  ebsOptimizedBaselineBandwidthPath,
+		ebsOptimizedBaselineThroughput: ebsOptimizedBaselineThroughputPath,
+		ebsOptimizedBaselineIOPS:       ebsOptimizedBaselineIOPSPath,
+	}
+
+	// determine if user used a shorthand for sorting flag
+	if sortFieldShorthandPath, ok := sortingKeysMap[sortField]; ok {
+		sortField = sortFieldShorthandPath
+	}
+
 	sorter, err := newSorter(instanceTypes, sortField, sortDirection)
 	if err != nil {
 		return nil, fmt.Errorf("an error occurred when preparing to sort instance types: %v", err)


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Added three new features to the bubble tea table. They can be used both individually and at the same time. These changes are intended to make it easier to compare instance types without having to re-run instance selector.
### 1) Filtering rows by strings. 

https://user-images.githubusercontent.com/68402662/183230532-1b3d0215-36cf-439d-becb-f49e14dc8e7c.mov

Only rows containing the passed in string will be visible. Exists in `tableView.go`

### 2) Trimming rows to only selected rows

https://user-images.githubusercontent.com/68402662/183230521-2c2f0b20-e2f8-4b10-ad8d-86eb24324054.mov

Trim the visible rows to only show selected rows. Exists in `tableView.go`

### 3) Sorting 

https://user-images.githubusercontent.com/68402662/183230422-dcee18ac-5dbe-4975-8eef-775849a8b07e.mov

Sort instance types using the same 2 methods available to CLI users: using shorthand flags (like memory, spot-price, etc.) or using a json path. Exists in `sortingView.go`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
