### PR TITLE
Fixed EKS testing bug

### DIFF
--- a/pkg/selector/eks_test.go
+++ b/pkg/selector/eks_test.go
@@ -109,8 +109,8 @@ func eksGithubReleaseHTTPServer(failLatestRelease bool, failExactRelease bool) *
 				w.WriteHeader(404)
 				return
 			}
-			w.WriteHeader(302)
 			w.Header().Add("location", "/releases/tag/v"+githubReleaseVersion)
+			w.WriteHeader(302)
 			return
 		}
 		if r.URL.Path == "/archive/v"+githubReleaseVersion+".zip" {


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Since the release of go 1.19, the EKS tests: `TestEKSDefaultService` and `TestEKSDefaultService_FailLatestReleaseUseFallbackStaticVersion` were failing due to the path to the testing zip file `amazon-eks-ami-20210125.zip` not being set correctly. 

In `eksGithubReleaseHTTPServer`, `w.Header().Add()` was being called after `w.WriteHeader()` which would mean that the header map was not being modified. The go documentation for `Header()` states: 
"Changing the header map after a call to WriteHeader (or Write) has no effect unless the HTTP status code was of the 1xx class or the modified headers are trailers."

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
