### PR TITLE
Fixed interactive table resizing bug

### DIFF
--- a/pkg/selector/outputs/tableView.go
+++ b/pkg/selector/outputs/tableView.go
@@ -249,12 +249,17 @@ func (m tableModel) resizeView(msg tea.WindowSizeMsg) tableModel {
 
 	// handle height changes
 	if headerAndFooterPadding >= msg.Height {
-		// height too short to fit rows
-		m.table = m.table.WithPageSize(0)
-		m.tableRowsPerPage = 0
+		// height too short to fit footer and header
+		// so only display 1 row
+		m.table = m.table.WithPageSize(1)
+		m.table = m.table.WithFooterVisibility(false)
+		m.table = m.table.WithHeaderVisibility(false)
+		m.tableRowsPerPage = 1
 	} else {
 		newRowsPerPage := msg.Height - headerAndFooterPadding
 		m.table = m.table.WithPageSize(newRowsPerPage)
+		m.table = m.table.WithFooterVisibility(true)
+		m.table = m.table.WithHeaderVisibility(true)
 		m.tableRowsPerPage = newRowsPerPage
 	}
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:
Previously, if you resized the terminal so that its height was less than the height of the table footer and header combined, a visual bug would occur where both the header and footer would disappear and there would be two highlighted rows. This is shown in the image below:
<img width="693" alt="Screen Shot 2022-08-11 at 2 58 50 PM" src="https://user-images.githubusercontent.com/68402662/184229319-741ae252-0f0e-4047-89e9-35e859bf8ace.png">

Now, if the terminal height is less than the height of the table footer and header combined, both the header and footer will be disabled and only 1 row will be visible. This prevents the visual bug from occurring while also leaving space for the filtering text to appear. The new format is shown below:
<img width="683" alt="Screen Shot 2022-08-11 at 2 59 30 PM" src="https://user-images.githubusercontent.com/68402662/184229776-70139308-57c8-4b43-8d1c-ea6051de20a7.png">



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
