### PR TITLE
fix gh action dependabot tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -22,7 +22,7 @@ jobs:
         go-version: ${{ env.DEFAULT_GO_VERSION }}
 
     - name: Check out code into the Go module directory
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
 
     - name: Unit Tests
       run: make unit-test
@@ -43,7 +43,7 @@ jobs:
       run: make build-docker-images
 
     - name: Integration Tests
-      if: github.event_name == 'push'
+      if: ${{ github.event_name == 'push' && !contains(github.ref, 'dependabot') }}
       run: make integ-test
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
Issue #, if available:

Description of changes:
 - Don't run integration tests on dependabot branches
 
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
