### PR TITLE
Update stale --cpu-architecture options in the README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ Filter Flags:
   -z, --availability-zones strings                     Availability zones or zone ids to check EC2 capacity offered in specific AZs
       --baremetal                                      Bare Metal instance types (.metal instances)
   -b, --burst-support                                  Burstable instance types
-  -a, --cpu-architecture string                        CPU architecture [x86_64/amd64, x86_64_mac, i386, or arm64]
+  -a, --cpu-architecture string                        CPU architecture [x86_64, x86_64_mac, i386, or arm64]
       --cpu-manufacturer string                        CPU manufacturer [amd, intel, aws]
       --current-generation                             Current generation instance types (explicitly set this to false to not return current generation instance types)
       --dedicated-hosts                                Dedicated Hosts supported


### PR DESCRIPTION

In the README.md, the following is stated about the CLI arguments:

```txt
-a, --cpu-architecture string                        CPU architecture [x86_64/amd64, x86_64_mac, i386, or arm64]
```

But running it with `x86_64/amd64` fails.
```bash
ec2-instance-selector \
    --cpu-architecture "x86_64/amd64" \
    -o interactive
```

Error is:

```txt
NOTE: There was an error while parsing the commandline flags: error cpu-architecture must be one of: x86_64, x86_64_mac, amd64, i386, arm64
```



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
