### PR TITLE
Update the syntax for linux installation commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,9 @@ brew install ec2-instance-selector
 #### Install w/ Curl for Linux/Mac
 
 ```
-$ curl -Lo ec2-instance-selector https://github.com/aws/amazon-ec2-instance-selector/releases/download/v2.4.1/ec2-instance-selector-`uname | tr '[:upper:]' '[:lower:]'`-amd64 && chmod +x ec2-instance-selector
-$ sudo mv ec2-instance-selector /usr/local/bin/
-$ ec2-instance-selector --version
+curl -Lo ec2-instance-selector https://github.com/aws/amazon-ec2-instance-selector/releases/download/v2.4.1/ec2-instance-selector-`uname | tr '[:upper:]' '[:lower:]'`-amd64 && chmod +x ec2-instance-selector
+sudo mv ec2-instance-selector /usr/local/bin/
+ec2-instance-selector --version
 ```
 
 To execute the CLI, you will need AWS credentials configured. Take a look at the [AWS CLI configuration documentation](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-configure.html#config-settings-and-precedence) for details on the various ways to configure credentials. An easy way to try out the ec2-instance-selector CLI is to populate the following environment variables with your AWS API credentials.


### PR DESCRIPTION
Remove the dollar sign at the beginning of the commands. Otherwise, copying and running the commands will copy the dollar sign too, which will throw an error.

Issue #, if available:

Description of changes:

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
