### PR TITLE
Fix issue using count/min/max of inference-accelerators

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -174,7 +174,7 @@ Full docs can be found at github.com/aws/amazon-` + binName
 	cli.ByteQuantityMinMaxRangeFlags(gpuMemoryTotal, nil, nil, "Number of GPUs' total memory (Example: 4 GiB)")
 	cli.StringFlag(gpuManufacturer, nil, nil, "GPU Manufacturer name (Example: NVIDIA)", nil)
 	cli.StringFlag(gpuModel, nil, nil, "GPU Model name (Example: K520)", nil)
-	cli.IntMinMaxRangeFlags(inferenceAccelerators, nil, nil, "Total Number of inference accelerators (Example: 4)")
+	cli.Int32MinMaxRangeFlags(inferenceAccelerators, nil, nil, "Total Number of inference accelerators (Example: 4)")
 	cli.StringFlag(inferenceAcceleratorManufacturer, nil, nil, "Inference Accelerator Manufacturer name (Example: AWS)", nil)
 	cli.StringFlag(inferenceAcceleratorModel, nil, nil, "Inference Accelerator Model name (Example: Inferentia)", nil)
 	cli.StringOptionsFlag(placementGroupStrategy, nil, nil, "Placement group strategy: [cluster, partition, spread]", []string{"cluster", "partition", "spread"})
@@ -387,7 +387,7 @@ Full docs can be found at github.com/aws/amazon-` + binName
 		GpuMemoryRange:                   cli.ByteQuantityRangeMe(flags[gpuMemoryTotal]),
 		GPUManufacturer:                  cli.StringMe(flags[gpuManufacturer]),
 		GPUModel:                         cli.StringMe(flags[gpuModel]),
-		InferenceAcceleratorsRange:       cli.IntRangeMe(flags[inferenceAccelerators]),
+		InferenceAcceleratorsRange:       cli.Int32RangeMe(flags[inferenceAccelerators]),
 		InferenceAcceleratorManufacturer: cli.StringMe(flags[inferenceAcceleratorManufacturer]),
 		InferenceAcceleratorModel:        cli.StringMe(flags[inferenceAcceleratorModel]),
 		PlacementGroupStrategy:           cli.StringMe(flags[placementGroupStrategy]),

--- a/pkg/selector/selector.go
+++ b/pkg/selector/selector.go
@@ -484,6 +484,14 @@ func exec(instanceType ec2types.InstanceType, filterName string, filter filterPa
 			if !isSupportedWithRangeInt64(iSpec, filter) {
 				return false, nil
 			}
+		case *int32:
+			var iSpec64 *int64
+			if iSpec != nil {
+				iSpec64 = aws.Int64(int64(*iSpec))
+			}
+			if !isSupportedWithRangeInt64(iSpec64, filter) {
+				return false, nil
+			}
 		case *int:
 			if !isSupportedWithRangeInt(iSpec, filter) {
 				return false, nil

--- a/pkg/selector/types.go
+++ b/pkg/selector/types.go
@@ -162,7 +162,7 @@ type Filters struct {
 	GPUModel *string
 
 	// InferenceAcceleratorsRange filters inference accelerators available to the instance type
-	InferenceAcceleratorsRange *IntRangeFilter
+	InferenceAcceleratorsRange *Int32RangeFilter
 
 	// InferenceAcceleratorManufacturer filters by inference acceleartor manufacturer
 	InferenceAcceleratorManufacturer *string


### PR DESCRIPTION
Issue #, if available: #413 

Description of changes: Do exactly what we do for `GpuMemoryRange` as that one works fine. which means we use the `Int32RangeFilter` 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

Here's the output:
```
❯ ./build/ec2-instance-selector --vcpus 8 --gpus 0 --memory 16GiB -a x86_64 --inference-accelerators 1
inf1.2xlarge
```
