### PR TITLE
revert inference-accelerator type change from int to int32

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -174,7 +174,7 @@ Full docs can be found at github.com/aws/amazon-` + binName
 	cli.ByteQuantityMinMaxRangeFlags(gpuMemoryTotal, nil, nil, "Number of GPUs' total memory (Example: 4 GiB)")
 	cli.StringFlag(gpuManufacturer, nil, nil, "GPU Manufacturer name (Example: NVIDIA)", nil)
 	cli.StringFlag(gpuModel, nil, nil, "GPU Model name (Example: K520)", nil)
-	cli.Int32MinMaxRangeFlags(inferenceAccelerators, nil, nil, "Total Number of inference accelerators (Example: 4)")
+	cli.IntMinMaxRangeFlags(inferenceAccelerators, nil, nil, "Total Number of inference accelerators (Example: 4)")
 	cli.StringFlag(inferenceAcceleratorManufacturer, nil, nil, "Inference Accelerator Manufacturer name (Example: AWS)", nil)
 	cli.StringFlag(inferenceAcceleratorModel, nil, nil, "Inference Accelerator Model name (Example: Inferentia)", nil)
 	cli.StringOptionsFlag(placementGroupStrategy, nil, nil, "Placement group strategy: [cluster, partition, spread]", []string{"cluster", "partition", "spread"})
@@ -387,7 +387,7 @@ Full docs can be found at github.com/aws/amazon-` + binName
 		GpuMemoryRange:                   cli.ByteQuantityRangeMe(flags[gpuMemoryTotal]),
 		GPUManufacturer:                  cli.StringMe(flags[gpuManufacturer]),
 		GPUModel:                         cli.StringMe(flags[gpuModel]),
-		InferenceAcceleratorsRange:       cli.Int32RangeMe(flags[inferenceAccelerators]),
+		InferenceAcceleratorsRange:       cli.IntRangeMe(flags[inferenceAccelerators]),
 		InferenceAcceleratorManufacturer: cli.StringMe(flags[inferenceAcceleratorManufacturer]),
 		InferenceAcceleratorModel:        cli.StringMe(flags[inferenceAcceleratorModel]),
 		PlacementGroupStrategy:           cli.StringMe(flags[placementGroupStrategy]),

--- a/pkg/selector/types.go
+++ b/pkg/selector/types.go
@@ -162,7 +162,7 @@ type Filters struct {
 	GPUModel *string
 
 	// InferenceAcceleratorsRange filters inference accelerators available to the instance type
-	InferenceAcceleratorsRange *Int32RangeFilter
+	InferenceAcceleratorsRange *IntRangeFilter
 
 	// InferenceAcceleratorManufacturer filters by inference acceleartor manufacturer
 	InferenceAcceleratorManufacturer *string


### PR DESCRIPTION
Issue #, if available:
N/A

Description of changes:
Whoops, realized this would break backwards compatibility. The filter evaluation in the inference-accelerator PR fixes this issue, so I'll revert the type changes. 

https://github.com/aws/amazon-ec2-instance-selector/commit/68daa33c473d8e391417c8f06717f6d2b64a0807

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
