### PR TITLE
Update setup command to get latest release

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ brew install ec2-instance-selector
 ```
 os=$(uname | tr 'A-Z' 'a-z')
 arch=$(printf "%s" "$(uname -m | tr 'A-Z' 'a-z' | sed -E 's/x86_64|i[3-6]86/amd64/;s/aarch64|arm64/arm64/')")
-curl -Lo ec2-instance-selector https://github.com/aws/amazon-ec2-instance-selector/releases/download/v3.1.0/ec2-instance-selector-$os-$arch && chmod +x ec2-instance-selector
+curl -Lo ec2-instance-selector https://github.com/aws/amazon-ec2-instance-selector/releases/latest/download/ec2-instance-selector-$os-$arch && chmod +x ec2-instance-selector
 sudo mv ec2-instance-selector /usr/local/bin/
 ec2-instance-selector --version
 ```


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Noticed v3.1.1 released but having v3.1.0 included in README.md.
- ref: https://github.com/aws/amazon-ec2-instance-selector/compare/v3.1.0...v3.1.1#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R53-R55

Better to have link always pointed to latest release

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
