### PR TITLE
Set newline to print version correctly

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -244,7 +244,7 @@ Full docs can be found at github.com/aws/amazon-` + binName
 	}
 
 	if flags[version] != nil {
-		fmt.Printf("%s", versionID)
+		fmt.Printf("%s\n", versionID)
 		os.Exit(0)
 	}
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Add a newline when printing `version` information.

Before:
```
$ ./ec2-instance-selector --version
devbash-3.2$
```

After:
```
$ ./ec2-instance-selector --version
dev
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
