### PR TITLE
add 3p licenses

### DIFF
--- a/THIRD_PARTY_LICENSES
+++ b/THIRD_PARTY_LICENSES
@@ -939,6 +939,10 @@ Copyright (c) 2020 Charmbracelet, Inc
 ** github.com/charmbracelet/bubbles; v0.13.0 --
 https://github.com/charmbracelet/bubbles
 Copyright (c) 2020 Charmbracelet, Inc
+** github.com/charmbracelet/x/cellbuf; v0.0.13 --
+https://github.com/charmbracelet/x
+** github.com/charmbracelet/colorprofile; v0.2.3 --
+https://github.com/charmbracelet/colorprofile
 
 MIT License
 
@@ -1530,6 +1534,32 @@ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 
+------
+
+** github.com/xo/terminfo; v0.0.0-20220910002029 --
+https://github.com/xo/terminfo
+
+The MIT License (MIT)
+
+Copyright (c) 2016 Anmol Sethi
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 ------
 

--- a/test/license-test/run-license-test.sh
+++ b/test/license-test/run-license-test.sh
@@ -10,7 +10,7 @@ LICENSE_TEST_TAG="aeis-license-test"
 LICENSE_REPORT_FILE="$BUILD_PATH/license-report"
 GOPROXY="direct|https://proxy.golang.org"
 
-SUPPORTED_PLATFORMS_LINUX="linux/amd64" make -s -f $SCRIPTPATH/../../Makefile build-binaries
+SUPPORTED_PLATFORMS="linux/amd64" make -s -f $SCRIPTPATH/../../Makefile build-binaries
 docker buildx build --load --build-arg=GOPROXY=${GOPROXY} -t $LICENSE_TEST_TAG $SCRIPTPATH/
 docker run -i -e GITHUB_TOKEN --rm -v $SCRIPTPATH/:/test -v $BUILD_BIN/:/aeis-bin $LICENSE_TEST_TAG golicense /test/license-config.hcl /aeis-bin/$BINARY_NAME | tee $LICENSE_REPORT_FILE
 $SCRIPTPATH/check-licenses.sh $LICENSE_REPORT_FILE


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws/amazon-ec2-instance-selector/issues/483

Description of changes:
- Add missing 3p licenses to fix build failure due to license validation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
